### PR TITLE
docs(g_lineplot.R): fixed a parameter's description

### DIFF
--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -35,7 +35,7 @@
 #' controls the type of the `mid` plot, it can be point (`p`), line (`l`), or point and line (`pl`).
 #' @param mid_point_size (`integer` or `double`) \cr
 #' controls the font size of the point for `mid` plot.
-#' @param position \cr
+#' @param position (`character` or `call`)\cr
 #' geom element position adjustment, either as a string, or the result of a call to a position adjustment function.
 #' @param legend_title (`character` string) \cr legend title.
 #' @param legend_position (`character`) \cr

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -78,7 +78,7 @@ controls the type of the \code{mid} plot, it can be point (\code{p}), line (\cod
 \item{mid_point_size}{(\code{integer} or \code{double}) \cr
 controls the font size of the point for \code{mid} plot.}
 
-\item{position}{\cr
+\item{position}{(\code{character} or \code{call})\cr
 geom element position adjustment, either as a string, or the result of a call to a position adjustment function.}
 
 \item{legend_title}{(\code{character} string) \cr legend title.}


### PR DESCRIPTION
* fixed a parameter's description which caused the Rd2pdf step of the R CMD check to fail
Closes #172