### PR TITLE
downgrade survival for enableR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
   rlang,
   scales,
   stats,
-  survival (>= 3.2-11),
+  survival (>= 3.1-11),
   utils,
   utils.nest (>= 0.2.11),
   forcats,


### PR DESCRIPTION
closes https://github.com/insightsengineering/tern/issues/180

We want to be compatible with enableR.

survival 3.2-13 -> 3.2-11