### PR TITLE
updat estage depenenccies

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -11,6 +11,9 @@ upstream_repos:
   insightsengineering/utils.nest:
     repo: insightsengineering/utils.nest
     host: https://github.com
+  insightsengineering/rbmi:
+    repo: insightsengineering/rbmi
+    host: https://github.com
   Roche/rtables:
     repo: Roche/rtables
     host: https://github.com


### PR DESCRIPTION
adding rbmi to staged dependencies, need fallback_branch for rbmi, but having trouble installing at the moment 

```
x <- do.call(staged.dependencies::dependency_table, 
  list(project = "/home/rstudio/nest_projects/tern", project_type = "local", direction = "upstream", 
  verbose = 1, fallback_branch = "master"))

do.call(staged.dependencies::install_deps, list(dep_structure = x, verbose = 1, install_project = TRUE))
```