### PR TITLE
Update test-tabulate_mmrm.R

### DIFF
--- a/tests/testthat/test-tabulate_mmrm.R
+++ b/tests/testthat/test-tabulate_mmrm.R
@@ -367,7 +367,7 @@ testthat::test_that("h_mmrm_diagnostic works as expected", {
   expected_matrix <- structure(
     c(
       "", "REML criterion", "AIC", "AICc", "BIC", "Diagnostic statistic value",
-      "1351.4", "1365.4", "1366", "1377.4"
+      "1351.4", "1365.4", "1366.0", "1377.4"
     ),
     .Dim = c(5L, 2L)
   )
@@ -562,7 +562,7 @@ testthat::test_that("summarize_lsmeans works as expected when treatment is not c
       "WEEK 2 DAY 15", "n", "Adjusted Mean (SE)", "95% CI", "WEEK 3 DAY 22",
       "n", "Adjusted Mean (SE)", "95% CI", "WEEK 4 DAY 29", "n", "Adjusted Mean (SE)",
       "95% CI", "WEEK 5 DAY 36", "n", "Adjusted Mean (SE)", "95% CI",
-      "all obs", "", "41", "50.486 (1.238)", "(48.03, 52.942)", "",
+      "all obs", "", "41", "50.486 (1.238)", "(48.030, 52.942)", "",
       "41", "48.703 (1.194)", "(46.346, 51.061)", "", "41", "51.187 (1.230)",
       "(48.752, 53.623)", "", "41", "50.029 (1.266)", "(47.527, 52.532)",
       "", "41", "50.843 (1.263)", "(48.323, 53.363)"


### PR DESCRIPTION
fix tests as currently we have a correct format for numbers with 0 at the end.

DRAFT