### PR TITLE
Fix tests

### DIFF
--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -24,8 +24,8 @@ testthat::test_that("estimate_coef works correctly", {
       ARMCD = droplevels(ARMCD),
       SEX = droplevels(SEX)
     )
-  mod <- coxph(
-    formula = Surv(time = AVAL, event = 1 - CNSR) ~ (SEX + ARMCD)^2,
+  mod <- survival::coxph(
+    formula = survival::Surv(time = AVAL, event = 1 - CNSR) ~ (SEX + ARMCD)^2,
     data = adtte
   )
 
@@ -48,14 +48,15 @@ testthat::test_that("estimate_coef works correctly", {
 })
 
 testthat::test_that("try_car_anova works correctly", {
-  mod <- coxph(
-    formula = Surv(time = futime, event = fustat) ~ factor(rx) + strata(ecog.ps),
+  mod <- survival::coxph(
+    formula = survival::Surv(time = futime, event = fustat) ~ factor(rx) + survival::strata(ecog.ps),
     data = survival::ovarian
   )
   result <- try_car_anova(mod = mod, test.statistic = "Wald")
   result_aov <- c(result$aov$Df, result$aov$Chisq, result$aov$`Pr(>Chisq)`)
 
-  testthat::expect_equal(result_aov, c(1, 0.7521, 0.3858), tolerance = 1e-3)
+  testthat::expect_equal(result_aov,
+                         c(1, 1, 0.9678, 0.3970, 0.3252, 0.5286), tolerance = 1e-3)
   testthat::expect_identical(result$warn_text, NULL)
 })
 
@@ -100,7 +101,7 @@ testthat::test_that("s_cox_multivariate works correctly with character input", {
     )
 
   result <- s_cox_multivariate(
-    formula = Surv(time = AVAL, event = 1 - CNSR) ~ (ARMCD + RACE + AGE)^2, data = adtte_f
+    formula = survival::Surv(time = AVAL, event = 1 - CNSR) ~ (ARMCD + RACE + AGE)^2, data = adtte_f
   )
   expected_aov <- matrix(
     c(2, 2, 1, 4, 2, 2, 1.5484, 0.4485, 0.0668, 3.3770, 0.2824, 0.6636, 0.4611, 0.7991, 0.7961, 0.4968, 0.8683, 0.7176),

--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -56,7 +56,9 @@ testthat::test_that("try_car_anova works correctly", {
   result_aov <- c(result$aov$Df, result$aov$Chisq, result$aov$`Pr(>Chisq)`)
 
   testthat::expect_equal(result_aov,
-                         c(1, 1, 0.9678, 0.3970, 0.3252, 0.5286), tolerance = 1e-3)
+    c(1, 1, 0.9678, 0.3970, 0.3252, 0.5286),
+    tolerance = 1e-3
+  )
   testthat::expect_identical(result$warn_text, NULL)
 })
 

--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -1,6 +1,9 @@
 testthat::test_that("pairwise works correctly", {
   result <- testthat::expect_warning(lm(SEX ~ pairwise(ARM), data = adsl_raw))
-  expected <- c("(Intercept)" = 1.41045, "pairwise(ARM)B: Placebo" = -0.02239, "pairwise(ARM)C: Combination" = 0.05925)
+  expected <- c(
+    "(Intercept)" = 1.41045, "pairwise(ARM)B: Placebo" = -0.02239,
+    "pairwise(ARM)C: Combination" = 0.05925
+  )
   testthat::expect_equal(result$coefficients, expected, tolerance = 1e-4)
 })
 

--- a/tests/testthat/test-summarize_glm_count.R
+++ b/tests/testthat/test-summarize_glm_count.R
@@ -56,9 +56,17 @@ testthat::test_that("h_glm_poisson emmeans-fit works with healthy input", {
   testthat::expect_equal(mat1$rate, expected$rate, tolerance = 0.0000001)
   testthat::expect_equal(mat1$std.error, expected$std.error, tolerance = 0.0000001)
   testthat::expect_equal(mat1$df, expected$df, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
   testthat::expect_equal(mat1$p.value, expected$p.value, tolerance = 0.0000001)
+
+  # Checking with older version of groom::tidy for emmGrid objects
+  if ("null" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
+  }
+  if ("statistic" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
+  } else {
+    testthat::expect_equal(mat1$z.ratio, expected$statistic, tolerance = 0.0000001)
+  }
 })
 
 testthat::test_that("h_glm_poisson fails wrong inputs", {
@@ -151,11 +159,19 @@ testthat::test_that("h_glm_quasipoisson emmeans-fit works with healthy input", {
 
   testthat::expect_equal(mat1$ARMCD, expected$ARMCD, tolerance = 0.0000001)
   testthat::expect_equal(mat1$rate, expected$rate, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$std.error, expected$std.error, tolerance = 0.1)
+  testthat::expect_equal(mat1$std.error, expected$std.error, tolerance = 0.000001)
   testthat::expect_equal(mat1$df, expected$df, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
   testthat::expect_equal(mat1$p.value, expected$p.value, tolerance = 0.0000001)
+
+  # Checking with older version of groom::tidy for emmGrid objects
+  if ("null" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
+  }
+  if ("statistic" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
+  } else {
+    testthat::expect_equal(mat1$z.ratio, expected$statistic, tolerance = 0.0000001)
+  }
 })
 
 testthat::test_that("h_glm_quasipoisson fails wrong inputs", {
@@ -236,9 +252,17 @@ testthat::test_that("h_glm_count emmeans-fit works with healthy input", {
   testthat::expect_equal(mat1$rate, expected$rate, tolerance = 0.0000001)
   testthat::expect_equal(mat1$std.error, expected$std.error, tolerance = 0.0000001)
   testthat::expect_equal(mat1$df, expected$df, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
-  testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
   testthat::expect_equal(mat1$p.value, expected$p.value, tolerance = 0.0000001)
+
+  # Checking with older version of groom::tidy for emmGrid objects
+  if ("null" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$null, expected$null, tolerance = 0.0000001)
+  }
+  if ("statistic" %in% colnames(mat1)) {
+    testthat::expect_equal(mat1$statistic, expected$statistic, tolerance = 0.0000001)
+  } else {
+    testthat::expect_equal(mat1$z.ratio, expected$statistic, tolerance = 0.0000001)
+  }
 })
 
 testthat::test_that("h_glm_count fails wrong inputs", {


### PR DESCRIPTION
There were two different bugs here. 

- [x] `broom::tidy` behaves differently for object `emmGrid` between version `0.7.x` and `1.0.x`
- [x] `survival` was missing as a reference in many tests. This has to be fixed generally too. In this case, in particular, it was generating a different output depending on the version. Please note that if I explicitly use `survival::strata` instead of just `strata`, the strata results are not dropped and the final values are quite different. @ayogasekaram @edelarua could you check what is the expected behavior here?

Fixes #743 
