### PR TITLE
Tidy Roxygen documentation (newlines & bullet lists)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Imports:
     rlang,
     scales,
     stats,
-    survival (>= 3.1-11),
+    survival (>= 3.2-13),
     tibble,
     tidyr,
     utils

--- a/R/abnormal.R
+++ b/R/abnormal.R
@@ -2,13 +2,13 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' Primary analysis variable `.var` indicates the abnormal range result (character or factor)
-#' and additional analysis variables are `id` (character or factor) and `baseline` (character or
-#' factor). For each direction specified in `abnormal` (e.g. high or low) count patients in the
+#' Primary analysis variable `.var` indicates the abnormal range result (`character` or `factor`)
+#' and additional analysis variables are `id` (`character` or `factor`) and `baseline` (`character` or
+#' `factor`). For each direction specified in `abnormal` (e.g. high or low) count patients in the
 #' numerator and denominator as follows:
 #' \describe{
-#'   \item{`num`}{the number of patients with this abnormality recorded while on treatment.}
-#'   \item{`denom`}{the number of patients with at least one post-baseline assessment.}
+#'   \item{num}{the number of patients with this abnormality recorded while on treatment.}
+#'   \item{denom}{the number of patients with at least one post-baseline assessment.}
 #' }
 #' Note, the denominator includes patients that might have other abnormal levels at baseline,
 #' and patients with missing baseline. Note, optionally patients with this abnormality at
@@ -23,7 +23,6 @@
 #'
 #' @name abnormal
 #' @include formats.R
-#'
 NULL
 
 #' @describeIn abnormal Statistics function which counts patients with abnormal range values

--- a/R/abnormal_by_baseline.R
+++ b/R/abnormal_by_baseline.R
@@ -6,18 +6,18 @@
 #' Note that `df` should be filtered to include only post-baseline records.
 #'
 #' Primary analysis variable `.var` indicates the abnormal range result (character or factor), and additional
-#'   analysis variables are `id` (character or factor) and `baseline` (character or factor). For each
-#'   direction specified in `abnormal` (e.g. high or low) we condition on baseline range result and count
-#'   patients in the numerator and denominator as follows:
-#' * `Not <abnormal>`
-#'   * `denom`: the number of patients without abnormality at baseline (excluding those with missing baseline)
-#'   * `num`:  the number of patients in `denom` who also have at least one abnormality post-baseline
-#' * `<Abnormal>`
-#'   * `denom`: the number of patients with abnormality at baseline
-#'   * `num`: the number of patients in `denom` who also have at least one abnormality post-baseline
-#' * `Total`
-#'   * `denom`: the number of patients with at least one valid measurement post-baseline
-#'   * `num`: the number of patients in `denom` who also have at least one abnormality post-baseline
+#' analysis variables are `id` (character or factor) and `baseline` (character or factor). For each
+#' direction specified in `abnormal` (e.g. high or low) we condition on baseline range result and count
+#' patients in the numerator and denominator as follows:
+#'   * `Not <Abnormal>`
+#'     * `denom`: the number of patients without abnormality at baseline (excluding those with missing baseline)
+#'     * `num`:  the number of patients in `denom` who also have at least one abnormality post-baseline
+#'   * `<Abnormal>`
+#'     * `denom`: the number of patients with abnormality at baseline
+#'     * `num`: the number of patients in `denom` who also have at least one abnormality post-baseline
+#'   * `Total`
+#'     * `denom`: the number of patients with at least one valid measurement post-baseline
+#'     * `num`: the number of patients in `denom` who also have at least one abnormality post-baseline
 #'
 #' @inheritParams argument_convention
 #' @param abnormal (`character`)\cr identifying the abnormal range level(s) in `.var`.
@@ -58,7 +58,7 @@ d_count_abnormal_by_baseline <- function(abnormal) {
 #'   Please note that if the baseline variable or analysis variable contains `NA`, it is expected that `NA` has been
 #'   conveyed to `na_level` appropriately beforehand with `df_explicit_na()` or `explicit_na()`.
 #'
-#' @param na_level (`string`) \cr the explicit `na_level` argument you used in the pre-processing steps (maybe with
+#' @param na_level (`string`)\cr the explicit `na_level` argument you used in the pre-processing steps (maybe with
 #'   `df_explicit_na()`). The default is `"<Missing>"`.
 #'
 #' @examples
@@ -140,6 +140,7 @@ s_count_abnormal_by_baseline <- function(df,
 
 #' @describeIn abnormal_by_baseline Formatted Analysis function which can be further customized by calling
 #'   [rtables::make_afun()] on it. It is used as `afun` in [rtables::analyze()].
+#'
 #' @return [a_count_abnormal_by_baseline()] returns the corresponding list with formatted [rtables::CellValue()].
 #'
 #' @examples
@@ -163,7 +164,6 @@ a_count_abnormal_by_baseline <- make_afun(
 #' @inheritParams argument_convention
 #'
 #' @examples
-#'
 #' # Layout creating function.
 #' basic_table() %>%
 #'   count_abnormal_by_baseline(var = "ANRIND", abnormal = c(High = "HIGH")) %>%

--- a/R/abnormal_by_marked.R
+++ b/R/abnormal_by_marked.R
@@ -1,4 +1,4 @@
-#' Count patients with marked laboratory abnormalities
+#' Count Patients with Marked Laboratory Abnormalities
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
@@ -7,27 +7,28 @@
 #' Additional analysis variables are `id` (character or factor) and `direction` indicating
 #' the direction of the abnormality (factor).
 #' Denominator is number of patients with at least one valid measurement during
-#' treatment (post-baseline), and patients in the numerator are considered as follows:
-#' * For `Single, not last` and `Last or replicated`: Numerator is number of patients
-#'   with `Single, not last` and `Last or replicated` levels, respectively.
-#' * For `Any`: Numerator is the number of patients with either single or
-#'   replicated marked abnormalities.
+#'   * For `Single, not last` and `Last or replicated`: Numerator is number of patients
+#'     with `Single, not last` and `Last or replicated` levels, respectively.
+#'   * For `Any`: Numerator is the number of patients with either single or
+#'     replicated marked abnormalities.
 #'
 #' @details Note that `Single, not last` and `Last or replicated` levels are
 #' mutually exclusive. If a patient has abnormalities that meet both the `Single, not last`
 #' and `Last or replicated` criteria, then the patient will be counted only under the `Last or replicated` category.
-
+#'
 #' @inheritParams argument_convention
 #' @param category (`list`)\cr with different marked category names for single
-#' and last or replicated.
-#' @name abnormal_by_marked
+#'   and last or replicated.
 #'
+#' @name abnormal_by_marked
 NULL
+
 #' @describeIn abnormal_by_marked Statistics function which returns
-#' the counts and fractions of patients with `Single, not last`, `Last or replicated` and `Any`
-#' marked laboratory abnormalities for a single `abnormal` level.
+#'   the counts and fractions of patients with `Single, not last`, `Last or replicated` and `Any`
+#'   marked laboratory abnormalities for a single `abnormal` level.
+#'
 #' @return [s_count_abnormal_by_marked()] the single statistic `count_fraction`
-#' with `Single, not last`, `Last or replicated` and `Any` results.
+#'   with `Single, not last`, `Last or replicated` and `Any` results.
 #'
 #' @examples
 #' library(dplyr)
@@ -157,7 +158,7 @@ a_count_abnormal_by_marked <- make_afun(
 )
 
 #' @describeIn abnormal_by_marked Layout creating function which can be used for creating tables,
-#' which can take statistics function arguments and additional format arguments (see below).
+#'   which can take statistics function arguments and additional format arguments (see below).
 #'
 #' @examples
 #' map <- unique(

--- a/R/abnormal_by_worst_grade.R
+++ b/R/abnormal_by_worst_grade.R
@@ -8,27 +8,27 @@
 #' For a certain direction (e.g. high or low) this function counts
 #' patients in the denominator as number of patients with at least one valid measurement during treatment,
 #' and patients in the numerator as follows:
-#'  * `1` to `4`: Numerator is number of patients with worst grades 1-4 respectively;
-#'  * `Any`: Numerator is number of patients with at least one abnormality, which means grade is different from 0.
+#'   * `1` to `4`: Numerator is number of patients with worst grades 1-4 respectively;
+#'   * `Any`: Numerator is number of patients with at least one abnormality, which means grade is different from 0.
 #'
 #' @details
 #' The pre-processing steps are crucial when using this function. From the standard
 #' lab grade variable `ATOXGR`, derive the following two variables:
-#' * A grade direction variable (e.g. `GRADE_DIR`) is required in order to obtain
-#'   the correct denominators when building the layout as it is used to define row splitting.
-#' * A toxicity grade variable (e.g. `GRADE_ANL`) where all negative values from
-#'   `ATOXGR` are replaced by their absolute values.
-#' * Prior to tabulation, `df` must filtered to include only post-baseline records with worst grade flags.
+#'   * A grade direction variable (e.g. `GRADE_DIR`) is required in order to obtain
+#'     the correct denominators when building the layout as it is used to define row splitting.
+#'   * A toxicity grade variable (e.g. `GRADE_ANL`) where all negative values from
+#'     `ATOXGR` are replaced by their absolute values.
+#'   * Prior to tabulation, `df` must filtered to include only post-baseline records with worst grade flags.
 #'
 #' @inheritParams argument_convention
 #'
 #' @name abnormal_by_worst_grade
-#'
 NULL
 
 #' @describeIn abnormal_by_worst_grade Statistics function which counts patients with worst grade,
 #'   consisting of counts and percentages of patients with worst grade
 #'   `1` to `4`, and `Any` non-zero grade.
+#'
 #' @return [s_count_abnormal_by_worst_grade()] the single statistic `count_fraction` with grade 1 to 4
 #'   and "Any" results.
 #'

--- a/R/abnormal_by_worst_grade_worsen.R
+++ b/R/abnormal_by_worst_grade_worsen.R
@@ -17,25 +17,22 @@ NULL
 #'
 #' Helper function to prepare a `df` for generate the patient count shift table
 #'
-#' @param adlb (`data frame`) \cr `ADLB` dataframe
-#' @param worst_flag_low (named `vector`) \cr
-#' Worst low post-baseline lab grade flag variable
-#' @param worst_flag_high (named `vector`) \cr
-#' Worst high post-baseline lab grade flag variable
-#' @param direction_var (`string`) \cr
-#' Direction variable specifying the direction of the shift table of interest.
-#' Only lab records flagged by `L`, `H` or `B` are included in the shift table.
-#'  * `L`: low direction only
-#'  * `H`: high direction only
-#'  * `B`: both low and high directions
+#' @param adlb (`data.frame`)\cr `ADLB` dataframe
+#' @param worst_flag_low (named `vector`)\cr Worst low post-baseline lab grade flag variable
+#' @param worst_flag_high (named `vector`)\cr Worst high post-baseline lab grade flag variable
+#' @param direction_var (`string`)\cr Direction variable specifying the direction of the shift table of interest.
+#'   Only lab records flagged by `L`, `H` or `B` are included in the shift table.
+#'   * `L`: low direction only
+#'   * `H`: high direction only
+#'   * `B`: both low and high directions
 #'
-#' @return [h_adlb_worsen()] returns the `adlb` `data frame` containing only the
-#' worst labs specified according to `worst_flag_low` or `worst_flag_high` for the
-#' direction specified according to `direction_var`. For instance, for a lab that is
-#' needed for the low direction only, only records flagged by `worst_flag_low` are
-#' selected. For a lab that is needed for both low and high directions, the worst
-#' low records are selected for the low direction, and the worst high record are selected
-#' for the high direction.
+#' @return [h_adlb_worsen()] returns the `adlb` `data.frame` containing only the
+#'   worst labs specified according to `worst_flag_low` or `worst_flag_high` for the
+#'   direction specified according to `direction_var`. For instance, for a lab that is
+#'   needed for the low direction only, only records flagged by `worst_flag_low` are
+#'   selected. For a lab that is needed for both low and high directions, the worst
+#'   low records are selected for the low direction, and the worst high record are selected
+#'   for the high direction.
 #' @seealso [abnormal_by_worst_grade_worsen]
 #'
 #' @examples
@@ -159,10 +156,10 @@ h_adlb_worsen <- function(adlb,
 #'
 #' @inheritParams argument_convention
 #' @inheritParams h_adlb_worsen
-#' @param baseline_var (`string`) \cr baseline lab grade variable
+#' @param baseline_var (`string`)\cr baseline lab grade variable
 #' @return [h_worsen_counter()] returns the counts and fraction of patients
-#' whose worst post-baseline lab grades are worse than their baseline grades, for
-#' post-baseline worst grades "1", "2", "3", "4" and "Any".
+#'   whose worst post-baseline lab grades are worse than their baseline grades, for
+#'   post-baseline worst grades "1", "2", "3", "4" and "Any".
 #' @seealso [abnormal_by_worst_grade_worsen]
 #'
 #' @examples
@@ -261,16 +258,16 @@ h_worsen_counter <- function(df, id, .var, baseline_var, direction_var) {
 }
 
 #' @describeIn abnormal_by_worst_grade_worsen Statistics function which calculates the
-#' counts and fraction of patients whose worst post-baseline lab grades are worse than
-#' their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
+#'   counts and fraction of patients whose worst post-baseline lab grades are worse than
+#'   their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
 #'
-#' @param variables (named `list` of `string`) \cr list of additional analysis variables including:
-#' * `id` (`string`): \cr subject variable name
-#' * `baseline_var` (`string`): \cr name of the data column containing baseline toxicity variable
-#' * `direction_var` (`string`): See `direction_var` for more detail
+#' @param variables (named `list` of `string`)\cr list of additional analysis variables including:
+#'   * `id` (`string`)\cr subject variable name.
+#'   * `baseline_var` (`string`)\cr name of the data column containing baseline toxicity variable.
+#'   * `direction_var` (`string`)\cr see `direction_var` for more details.
 #' @return [s_count_abnormal_lab_worsen_by_baseline()] returns the
-#' counts and fraction of patients whose worst post-baseline lab grades are worse than
-#' their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
+#'   counts and fraction of patients whose worst post-baseline lab grades are worse than
+#'   their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
 #'
 #' @examples
 #' library(dplyr)
@@ -327,10 +324,9 @@ s_count_abnormal_lab_worsen_by_baseline <- function(df, # nolint
 
 
 #' @describeIn abnormal_by_worst_grade_worsen
-#' Formatted Analysis function which can be further customized by
-#' calling [rtables::make_afun()] on it. It is used as `afun` in [rtables::analyze()].
-#' @return [a_count_abnormal_lab_worsen_by_baseline()] returns
-#' the corresponding list with formatted [rtables::CellValue()].
+#'
+#' @return [a_count_abnormal_lab_worsen_by_baseline()] returns the corresponding list with
+#'   formatted [rtables::CellValue()].
 #'
 #' @examples
 #' # Internal function - a_count_abnormal_lab_worsen_by_baseline
@@ -349,9 +345,8 @@ a_count_abnormal_lab_worsen_by_baseline <- make_afun( # nolint
   .ungroup_stats = "fraction"
 )
 
-#' @describeIn abnormal_by_worst_grade_worsen Layout
-#' creating function which can be used for creating tables, which can take statistics
-#' function arguments and additional format arguments (see below).
+#' @describeIn abnormal_by_worst_grade_worsen Layout creating function which can be used for creating tables,
+#'   which can take statistics function arguments and additional format arguments (see below).
 #'
 #' @examples
 #' basic_table() %>%

--- a/R/analyze_vars_in_cols.R
+++ b/R/analyze_vars_in_cols.R
@@ -15,7 +15,7 @@ NULL
 #' @inheritParams argument_convention
 #' @inheritParams rtables::analyze_colvars
 #'
-#' @seealso [summarize_vars], [rtables::analyze_colvars].
+#' @seealso [summarize_vars], [`rtables::analyze_colvars()`].
 #'
 #' @export
 #' @examples

--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -10,30 +10,30 @@
 #' `@inheritParams argument_convention`
 #'
 #' @param ... additional arguments for the lower level functions.
-#' @param .df_row (`data frame`)\cr data frame across all of the columns for the given row split.
+#' @param .df_row (`data.frame`)\cr data frame across all of the columns for the given row split.
 #' @param .in_ref_col (`logical`)\cr `TRUE` when working with the reference level, `FALSE` otherwise.
 #' @param .N_col (`count`)\cr row-wise N (row group count) for the group of observations being analyzed
 #'   (i.e. with no column-based subsetting) that is passed by `rtables`.
 #' @param .N_row (`count`)\cr column-wise N (column count) for the full column that is passed by `rtables`.
-#' @param .ref_group (`data frame` or `vector`)\cr the data corresponding to the reference group.
+#' @param .ref_group (`data.frame` or `vector`)\cr the data corresponding to the reference group.
 #' @param .stats (`character`)\cr statistics to select for the table.
 #' @param .indent_mods (named `integer`)\cr indent modifiers for the labels.
 #' @param .formats (named `character` or `list`)\cr formats for the statistics.
 #' @param .labels (named `character`)\cr labels for the statistics (without indent).
 #' @param .var (`string`)\cr single variable name that is passed by `rtables` when requested
 #'   by a statistics function.
-#' @param .spl_context (`data frame`)\cr gives information about ancestor split states
+#' @param .spl_context (`data.frame`)\cr gives information about ancestor split states
 #'   that is passed by `rtables`.
 #' @param col_by (`factor`)\cr defining column groups.
 #' @param conf_level (`proportion`)\cr confidence level of the interval.
 #' @param data (`data.frame`)\cr the dataset containing the variables to summarize.
-#' @param df (`data frame`)\cr data set containing all analysis variables.
+#' @param df (`data.frame`)\cr data set containing all analysis variables.
 #' @param draw (`flag`)\cr whether the plot should be drawn.
 #' @param drop (`flag`)\cr should non appearing occurrence levels be dropped from the resulting table.
 #'   Note that in that case the remaining occurrence levels in the table are sorted alphabetically.
-#' @param id (`string`) \cr subject variable name.
+#' @param id (`string`)\cr subject variable name.
 #' @param is_event (`logical`)\cr `TRUE` if event, `FALSE` if time to event is censored.
-#' @param indent_mod (`count`) \cr it can be negative. Modifier for the default indent position for the
+#' @param indent_mod (`count`)\cr it can be negative. Modifier for the default indent position for the
 #'   structure created by this function(subtable, content table, or row) and
 #'   all of that structure's children. Defaults to 0, which corresponds to the
 #'   unmodified default behavior.

--- a/R/compare_variables.R
+++ b/R/compare_variables.R
@@ -33,8 +33,8 @@ s_compare <- function(x,
 #' @describeIn compare_variables Method for numeric class. This uses the standard t-test
 #'   to calculate the p-value.
 #' @return If `x` is of class `numeric`, returns a list with named items:
-#' - all items from [s_summary.numeric()].
-#' - `pval`: the p-value.
+#'   - all items from [s_summary.numeric()].
+#'   - `pval`: the p-value.
 #' @method s_compare numeric
 #'
 #' @export
@@ -77,8 +77,7 @@ s_compare.numeric <- function(x,
 #'   missing values should be accounted for explicitly as factor levels.
 #' @param denom (`string`)\cr choice of denominator for factor proportions,
 #'   can only be `n` (number of values in this row and column intersection).
-#' @return If `x` is of class `factor` or converted from `character`, returns a list with
-#'   named items:
+#' @return If `x` is of class `factor` or converted from `character`, returns a list with named items:
 #'   - all items from [s_summary.factor()].
 #'   - `pval`: the p-value.
 #' @method s_compare factor

--- a/R/control_incidence_rate.R
+++ b/R/control_incidence_rate.R
@@ -6,10 +6,10 @@
 #' internally to specify details in `s_incidence_rate()`.
 #'
 #' @inheritParams argument_convention
-#' @param time_unit_input (`string`) \cr `day`, `month`, or `year` (default)
+#' @param time_unit_input (`string`)\cr `day`, `month`, or `year` (default)
 #'   indicating time unit for data input.
-#' @param time_unit_output (`numeric`) \cr time unit for desired output (in person-years).
-#' @param conf_type (`string`) \cr `normal` (default), `normal_log`, `exact`, or `byar`
+#' @param time_unit_output (`numeric`)\cr time unit for desired output (in person-years).
+#' @param conf_type (`string`)\cr `normal` (default), `normal_log`, `exact`, or `byar`
 #'   for confidence interval type.
 #' @return A list of components with the same name as the arguments.
 #' @export

--- a/R/control_survival.R
+++ b/R/control_survival.R
@@ -5,9 +5,9 @@
 #' This is an auxiliary function for controlling arguments for `CoxPH` model, typically used internally to specify
 #' details of `CoxPH` model for [s_coxph_pairwise]. `conf_level` refers to Hazard Ratio estimation.
 #'
-#' @param pval_method (`string`) \cr p-value method for testing hazard ratio = 1.
+#' @param pval_method (`string`)\cr p-value method for testing hazard ratio = 1.
 #'   Default method is \code{"log-rank"}, can also be set to \code{"wald"} or \code{"likelihood"}.
-#' @param ties 	(`string`) \cr specifying the method for tie handling. Default is \code{"efron"},
+#' @param ties 	(`string`)\cr specifying the method for tie handling. Default is \code{"efron"},
 #'   can also be set to \code{"breslow"} or \code{"exact"}. see more in [survival::coxph()]
 #' @inheritParams argument_convention
 #' @return A list of components with the same names as the arguments
@@ -31,9 +31,9 @@ control_coxph <- function(pval_method = c("log-rank", "wald", "likelihood"),
 #' details of `survfit` model for [s_surv_time]. `conf_level` refers to survival time estimation.
 #'
 #' @inheritParams argument_convention
-#' @param conf_type (`string`) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-#'    see more in [survival::survfit()]. Note that the option "none" is no longer supported.
-#' @param quantiles (`numeric`) \cr of length two to specify the quantiles of survival time.
+#' @param conf_type (`string`)\cr confidence interval type. Options are "plain" (default), "log", "log-log",
+#'   see more in [survival::survfit()]. Note option "none" is no longer supported.
+#' @param quantiles (`numeric`)\cr of length two to specify the quantiles of survival time.
 #' @return A list of components with the same names as the arguments
 #'
 #' @export

--- a/R/count_cumulative.R
+++ b/R/count_cumulative.R
@@ -8,15 +8,13 @@
 #' @seealso Relevant helper function [h_count_cumulative()], and descriptive function [d_count_cumulative()]
 #'
 #' @name count_cumulative
-#'
 NULL
 
 #' Helper Function for [s_count_cumulative()]
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' Helper function to calculate count and fraction of
-#' `x` values in the lower or upper tail given a threshold.
+#' Helper function to calculate count and fraction of `x` values in the lower or upper tail given a threshold.
 #'
 #' @inheritParams argument_convention
 #' @param threshold (`number`)\cr a cutoff value as threshold to count values of `x`.
@@ -24,10 +22,13 @@ NULL
 #' @param include_eq (`logical`)\cr whether to include value equal to the `threshold` in
 #' count, default is `TRUE`.
 #' @param .N_col (`count`)\cr denominator for fraction calculation.
-#' @return A named vector of 2:
-#'   - `count`: the count of values less than, less or equal to, greater than, or
-#'   greater or equal to a threshold of user specification.
-#'   - `fraction`: the fraction of the count.
+#' @return A named vector with items:
+#' \describe{
+#'   \item{count}{the count of values less than, less or equal to, greater than, or greater or equal to a threshold
+#'     of user specification.
+#'   }
+#'   \item{fraction}{the fraction of the count.}
+#' }
 #' @seealso [count_cumulative]
 #'
 #' @export
@@ -86,12 +87,11 @@ d_count_cumulative <- function(threshold, lower_tail, include_eq) {
   paste0(lg, eq, " ", threshold)
 }
 
-#' @describeIn count_cumulative Statistics function that produces a named lists given a
-#' (`numeric`) vector of thresholds.
+#' @describeIn count_cumulative Statistics function that produces a named lists given a numeric vector of thresholds.
+#'
 #' @inheritParams h_count_cumulative
 #' @param thresholds (`numeric`)\cr vector of cutoff value for the counts.
-#' @return A named list:
-#'   - `count_fraction`: a list with each `thresholds` value as a component, each component
+#' @return A named list of `count_fraction`s: a list with each `thresholds` value as a component, each component
 #'     contains a vector for the count and fraction.
 #'
 #' @examples
@@ -125,6 +125,7 @@ s_count_cumulative <- function(x,
 
 #' @describeIn count_cumulative Formatted Analysis function which can be further customized by calling
 #'   [rtables::make_afun()] on it. It is used as `afun` in [rtables::analyze()].
+#'
 #' @return [a_count_cumulative()] returns the corresponding list with formatted [rtables::CellValue()].
 #'
 #' @examples
@@ -146,8 +147,10 @@ a_count_cumulative <- make_afun(
 #'   summary tables for cumulative counts of a variable. The ellipsis (`...`) conveys
 #'   arguments to `s_count_cumulative()`, for instance `lower_tail = FALSE` if upper tail
 #'   should be accounted for.
+#'
 #' @inheritParams argument_convention
 #' @export
+#'
 #' @examples
 #' basic_table() %>%
 #'   split_cols_by("ARM") %>%
@@ -157,7 +160,6 @@ a_count_cumulative <- make_afun(
 #'     thresholds = c(40, 60)
 #'   ) %>%
 #'   build_table(tern_ex_adsl)
-#'
 count_cumulative <- function(lyt,
                              vars,
                              var_labels = vars,

--- a/R/count_occurrences.R
+++ b/R/count_occurrences.R
@@ -17,17 +17,16 @@ NULL
 
 #' @describeIn count_occurrences Statistics function which counts number of patients that report an
 #' occurrence.
-#' @param denom (`string`)\cr choice of denominator for patient proportions:\cr
-#'   can be `N_col` (total number of patients in this column across rows) or
-#'   `n` (number of patients with any occurrences).
 #'
-#'
+#' @param denom (`string`)\cr choice of denominator for patient proportions. Can be:
+#'   - `N_col`: total number of patients in this column across rows
+#'   - `n`: number of patients with any occurrences
 #' @returns A list with:
-#'   - `count`: list of counts with one element per occurrence
-#'   - `count_fraction`: list of counts and fractions with one element per occurrence.
-#'   - `fraction`: list of numerators and denominators with one element per occurrence.
-#'
-#' @export
+#' \describe{
+#'   \item{count}{list of counts with one element per occurrence.}
+#'   \item{count_fraction}{list of counts and fractions with one element per occurrence.}
+#'   \item{fraction}{list of numerators and denominators with one element per occurrence.}
+#' }
 #'
 #' @examples
 #' df <- data.frame(
@@ -45,6 +44,8 @@ NULL
 #'   .var = "MHDECOD",
 #'   id = "USUBJID"
 #' )
+#'
+#' @export
 s_count_occurrences <- function(df,
                                 denom = c("N_col", "n"),
                                 .N_col, # nolint

--- a/R/count_patients_events_in_cols.R
+++ b/R/count_patients_events_in_cols.R
@@ -11,6 +11,7 @@ NULL
 
 #' @describeIn count_patients_events_in_cols Statistics function which counts numbers of patients and multiple events
 #'   defined by filters.
+#'
 #' @inheritParams argument_convention
 #' @param filters_list (named `list` of `character`)\cr each element in this list describes one
 #'   type of event describe by filters, in the same format as [s_count_patients_with_event()].
@@ -20,13 +21,13 @@ NULL
 #' @param custom_label (`string` or `NULL`)\cr if provided and `labelstr` is empty then this will
 #'   be used as label.
 #'
-#' @return [s_count_patients_and_multiple_events()] returns a list with the statistics:\cr
-#' - `unique`: number of unique patients in `df`.
-#' - `all`: number of rows in `df`.
-#' - one element with the same name as in `filters_list`: number of rows in `df`,
-#'   i.e. events, fulfilling the filter condition.
-#' @examples
+#' @return [s_count_patients_and_multiple_events()] returns a list with the statistics:
+#'   - `unique`: number of unique patients in `df`.
+#'   - `all`: number of rows in `df`.
+#'   - one element with the same name as in `filters_list`: number of rows in `df`,
+#'     i.e. events, fulfilling the filter condition.
 #'
+#' @examples
 #' # `s_count_patients_and_multiple_events()`
 #' df <- data.frame(
 #'   USUBJID = rep(c("id1", "id2", "id3", "id4"), c(2, 3, 1, 1)),

--- a/R/cox_regression.R
+++ b/R/cox_regression.R
@@ -489,12 +489,13 @@ NULL
 
 #' @describeIn fit_coxreg Fit a series of univariate Cox regression models
 #'   given the inputs.
+#'
 #' @param variables (`list`)\cr a named list corresponds to the names of variables found
 #'   in `data`, passed as a named list and corresponding to `time`, `event`, `arm`,
 #'   `strata`, and `covariates` terms. If `arm` is missing from `variables`, then
 #'   only Cox model(s) including the `covariates` will be fitted and the corresponding
 #'   effect estimates will be tabulated later.
-#' @param data (`data frame`)\cr the dataset containing the variables to fit the
+#' @param data (`data.frame`)\cr the dataset containing the variables to fit the
 #'   models.
 #' @param at (`list` of `numeric`)\cr when the candidate covariate is a
 #'  `numeric`, use `at` to specify the value of the covariate at which the
@@ -503,13 +504,14 @@ NULL
 #'   helper function [control_coxreg()].
 #' @return The function `fit_coxreg_univar` returns a `coxreg.univar` class object which is a named list
 #' with 5 elements:
-#'   - `mod`: Cox regression models fitted by [survival::coxph()].
-#'   - `data`: The original data frame input.
-#'   - `control`: The original control input.
-#'   - `vars`: The variables used in the model.
-#'   - `at`: Value of the covariate at which the effect should be estimated.
+#' \describe{
+#'   \item{mod}{Cox regression models fitted by [survival::coxph()].}
+#'   \item{data}{The original data frame input.}
+#'   \item{control}{The original control input.}
+#'   \item{vars}{The variables used in the model.}
+#'   \item{at}{Value of the covariate at which the effect should be estimated.}
+#' }
 #' @note When using `fit_coxreg_univar` there should be two study arms.
-#' @export
 #'
 #' @examples
 #' # fit_coxreg_univar
@@ -552,6 +554,8 @@ NULL
 #'   ),
 #'   data = dta_bladder
 #' )
+#'
+#' @export
 fit_coxreg_univar <- function(variables,
                               data,
                               at = list(),
@@ -598,12 +602,13 @@ fit_coxreg_univar <- function(variables,
 #' @describeIn fit_coxreg Fit a multi-variable Cox regression model.
 #'
 #' @return The function `fit_coxreg_multivar` returns a `coxreg.multivar` class object which is a named list
-#'   with 4 elements:
-#'   - `mod`: Cox regression model fitted by [survival::coxph()].
-#'   - `data`: The original data frame input.
-#'   - `control`: The original control input.
-#'   - `vars`: The variables used in the model.
-#' @export
+#' with 4 elements:
+#' \describe{
+#'   \item{mod}{Cox regression model fitted by [survival::coxph()].}
+#'   \item{data}{The original data frame input.}
+#'   \item{control}{The original control input.}
+#'   \item{vars}{The variables used in the model.}
+#' }
 #'
 #' @examples
 #' # fit_coxreg_multivar
@@ -625,6 +630,8 @@ fit_coxreg_univar <- function(variables,
 #'   ),
 #'   data = dta_bladder
 #' )
+#'
+#' @export
 fit_coxreg_multivar <- function(variables,
                                 data,
                                 control = control_coxreg()) {

--- a/R/cox_regression_inter.R
+++ b/R/cox_regression_inter.R
@@ -116,7 +116,7 @@ h_coxreg_inter_effect.numeric <- function(x, # nolint
 #' @describeIn cox_regression_inter Estimate the interaction with a factor
 #'   covariate.
 #'
-#' @param data (`data frame`)\cr the data frame on which the model was fit.
+#' @param data (`data.frame`)\cr the data frame on which the model was fit.
 #' @export
 h_coxreg_inter_effect.factor <- function(x, # nolint
                                          effect,
@@ -209,19 +209,18 @@ h_coxreg_extract_interaction <- function(effect,
 
 #' @describeIn cox_regression_inter hazard ratio estimation in interactions.
 #'
-#' @param variable,given (`string`)\cr
-#'   the name of variables in interaction. We seek the estimation of the levels
-#'   of `variable` given the levels of `given`.
-#' @param lvl_var,lvl_given (`character`)\cr
-#'   corresponding levels has given by [levels()].
-#' @param mod (`coxph`)\cr a fitted Cox regression model (see [survival::coxph()]).
 #' @inheritParams argument_convention
+#' @param variable,given (`string`)\cr the name of variables in interaction. We seek the estimation
+#'   of the levels of `variable` given the levels of `given`.
+#' @param lvl_var,lvl_given (`character`)\cr corresponding levels has given by [levels()].
+#' @param mod (`coxph`)\cr a fitted Cox regression model (see [survival::coxph()]).
+#'
 #' @details Given the cox regression investigating the effect of Arm (A, B, C; reference A)
 #'   and Sex (F, M; reference Female) and the model being abbreviated: y ~ Arm + Sex + Arm:Sex.
 #'   The cox regression estimates the coefficients along with a variance-covariance matrix for:
 #'
-#'   - b1 (arm b), b2 (arm c),
-#'   - b3 (sex m),
+#'   - b1 (arm b), b2 (arm c)
+#'   - b3 (sex m)
 #'   - b4 (arm b: sex m), b5 (arm c: sex m)
 #'
 #'   The estimation of the Hazard Ratio for arm C/sex M is given in reference
@@ -232,13 +231,11 @@ h_coxreg_extract_interaction <- function(effect,
 #' @return A list of matrix (one per level of variable) with rows corresponding to the combinations of
 #' `variable` and `given`, with columns:
 #' \describe{
-#'   \item{coef_hat}{Estimation of the coefficient}
+#'   \item{coef_hat}{Estimation of the coefficient.}
 #'   \item{coef_se}{Standard error of the estimation.}
 #'   \item{hr}{Hazard ratio.}
-#'   \item{lcl,ucl}{lower/upper confidence limit of the hazard ratio}
+#'   \item{lcl, ucl}{Lower/upper confidence limit of the hazard ratio.}
 #' }
-#'
-#' @export
 #'
 #' @examples
 #' mod <- coxph(Surv(time, status) ~ armcd * covar1, data = dta_bladder)
@@ -249,6 +246,8 @@ h_coxreg_extract_interaction <- function(effect,
 #'   mod = mod, conf_level = .95
 #' )
 #' result
+#'
+#' @export
 h_coxreg_inter_estimations <- function(variable, given,
                                        lvl_var, lvl_given,
                                        mod,

--- a/R/coxph.R
+++ b/R/coxph.R
@@ -1,4 +1,4 @@
-#' Pairwise formula special term
+#' Pairwise Formula Special Term
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
@@ -8,16 +8,16 @@
 #' @param x the variable for which pairwise result is expected
 #'
 #' @details Let's `ARM` being a factor with level A, B, C; let's be B the reference level,
-#'  a model calling the formula including `pairwise(ARM)` will result in two models
-#'  * a model including only levels A and B, and effect of A estimated in reference to B.
-#'  * a model including only levels C and B, the effect of C estimated in reference to B.
+#'   a model calling the formula including `pairwise(ARM)` will result in two models:
+#'   * A model including only levels A and B, and effect of A estimated in reference to B.
+#'   * A model including only levels C and B, the effect of C estimated in reference to B.
 #'
 #' @export
 pairwise <- function(x) {
   structure(x, varname = deparse(substitute(x)))
 }
 
-#' Univariate formula special term
+#' Univariate Formula Special Term
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
@@ -51,9 +51,9 @@ rht <- function(x) {
 #' This function estimates the hazard ratios between arms when an interaction variable is given with
 #' specific values.
 #'
-#' @param variable,given Names of two variable in interaction. We seek the estimation of the levels of \code{variable}
-#'   given the levels of \code{given}
-#' @param lvl_var,lvl_given corresponding levels has given by \code{levels}.
+#' @param variable,given Names of two variable in interaction. We seek the estimation of the levels of `variable`
+#'   given the levels of `given`.
+#' @param lvl_var,lvl_given corresponding levels has given by `levels`.
 #' @param mmat A name numeric filled with 0 used as template to obtain the design matrix.
 #' @param coef Numeric of estimated coefficients.
 #' @param vcov Variance-covariance matrix of underlying model.
@@ -63,8 +63,8 @@ rht <- function(x) {
 #'   and Sex (F, M; reference Female). The model is abbreviated: y ~ Arm + Sex + Arm x Sex.
 #'   The cox regression estimates the coefficients along with a variance-covariance matrix for:
 #'
-#'   - b1 (arm b), b2 (arm c),
-#'   - b3 (sex m),
+#'   - b1 (arm b), b2 (arm c)
+#'   - b3 (sex m)
 #'   - b4 (arm b: sex m), b5 (arm c: sex m)
 #'
 #'   Given that I want an estimation of the Hazard Ratio for arm C/sex M, the estimation
@@ -73,12 +73,12 @@ rht <- function(x) {
 #'   as $1.96 * sqrt(Var b2 + Var b5 + 2 * covariance (b2,b5))$ for a confidence level of 0.95.
 #'
 #' @return A list of matrix (one per level of variable) with rows corresponding to the combinations of
-#' \code{variable} and \code{given}, with columns:
+#' `variable` and `given`, with columns:
 #' \describe{
-#'   \item{coef_hat}{Estimation of the coefficient}
+#'   \item{coef_hat}{Estimation of the coefficient.}
 #'   \item{coef_se}{Standard error of the estimation.}
 #'   \item{hr}{Hazard ratio.}
-#'   \item{lcl,ucl}{lower/upper confidence limit of the hazard ratio}
+#'   \item{lcl, ucl}{Lower/upper confidence limit of the hazard ratio.}
 #' }
 #' @seealso [s_cox_multivariate()].
 #'
@@ -334,18 +334,18 @@ check_increments <- function(increments, covariates) {
 #' the p.values need to be interpreted with caution. (**Statistical Analysis of Clinical Trials Data with R**,
 #' `NEST's bookdown`)
 #'
-#' @param formula A \code{formula} corresponding to the investigated \code{\link[survival:Surv]{survival model}}
-#'     including covariates.
-#' @param data A \code{data.frame} which includes the variable in formula and covariates.
-#' @param conf_level The level of confidence for the hazard ration interval estimations. Default is 0.95.
-#' @param pval_method The method used for the estimation of p.values, should be one of \code{"wald"} (default) or
-#'   \code{"likelihood"}.
-#' @param ... Optional parameters passed to \code{\link[survival:coxph]{coxph()}}
-#' + `ties` a character string specifying the method for tie handling, one of `exact` (default), `efron`, `breslow`.
+#' @param formula (`formula`)\cr A formula corresponding to the investigated [survival::Surv()] survival model
+#'   including covariates.
+#' @param data (`data.frame`)\cr A data frame which includes the variable in formula and covariates.
+#' @param conf_level (`proportion`)\cr The confidence level for the hazard ratio interval estimations. Default is 0.95.
+#' @param pval_method (`character`)\cr The method used for the estimation of p-values, should be one of
+#'   "wald" (default) or "likelihood".
+#' @param ... Optional parameters passed to [survival::coxph()]. Can include `ties`, a character string specifying the
+#'   method for tie handling, one of `exact` (default), `efron`, `breslow`.
 #'
 #' @details The output is limited to single effect terms. Work in ongoing for estimation of interaction terms
-#'     but is out of scope as defined by the  Global Data Standards Repository
-#'     (**`GDS_Standard_TLG_Specs_Tables_2.doc`**).
+#'   but is out of scope as defined by the  Global Data Standards Repository
+#'   (**`GDS_Standard_TLG_Specs_Tables_2.doc`**).
 #' @seealso [estimate_coef()].
 #'
 #' @examples

--- a/R/desctools_binom_diff.R
+++ b/R/desctools_binom_diff.R
@@ -4,9 +4,9 @@
 #'
 #' Several confidence intervals for the difference between proportions.
 #'
-#' @param grp (`factor`)\cr
-#'   vector assigning observations to one out of two groups
+#' @param grp (`factor`)\cr vector assigning observations to one out of two groups
 #'   (e.g. reference and treatment group).
+#'
 #' @name desctools_binom
 
 NULL
@@ -26,15 +26,16 @@ h_recycle <- function(...) {
 
 #' @describeIn desctools_binom Several Confidence Intervals for the difference between proportions.
 #'
-#'
 #' @return A named list of 3 values:
-#'   - `est`: estimate of proportion difference.
-#'   - `lwrci`: estimate of lower end of the confidence interval
-#'   - `upci`: estimate of upper end of the confidence interval.
-#' @examples
-#' # Internal function -
-#' \dontrun{
+#' \describe{
+#'   \item{est}{estimate of proportion difference.}
+#'   \item{lwrci}{estimate of lower end of the confidence interval.}
+#'   \item{upci}{estimate of upper end of the confidence interval.}
+#' }
 #'
+#' @examples
+#' # Internal function - desctools_binom
+#' \dontrun{
 #' set.seed(2)
 #' rsp <- sample(c(TRUE, FALSE), replace = TRUE, size = 20)
 #' grp <- factor(c(rep("A", 10), rep("B", 10)))
@@ -343,29 +344,34 @@ desctools_binom <- function(x1, n1, x2, n2, conf.level = 0.95, sides = c(
 
 #' @describeIn desctools_binom Compute confidence intervals for binomial proportions.
 #'
-#' @param x \cr number of successes
-#' @param n \cr number of trials
-#' @param conf.level \cr confidence level, defaults to 0.95
-#' @param sides \cr a character string specifying the side of the confidence interval. Must be one of "two-sided" (default), "left" or "right".
-#' @param method \cr character string specifying which method to use. Can be one out of: "wald", "wilson", "wilsoncc", "agresti-coull", "jeffreys", "modified wilson", "modified jeffreys", "clopper-pearson", "arcsine.
-#' ", "logit", "witting", "pratt", "midp", "lik" and "blaker"
-#'
-#'
-#'  @return A matric with 3 columns containing:
-#'   - `est`: estimate of proportion difference.
-#'   - `lwrci`: lower end of the confidence interval
-#'   - `upci`:  upper end of the confidence interval.
+#' @param x (`count`)\cr number of successes
+#' @param n (`count`)\cr number of trials
+#' @param conf.level (`proportion`)\cr confidence level, defaults to 0.95.
+#' @param sides (`character`)\cr side of the confidence interval to compute. Must be one of "two-sided" (default),
+#'   "left", or "right".
+#' @param method (`character`)\cr method to use. Can be one out of: "wald", "wilson", "wilsoncc", "agresti-coull",
+#'   "jeffreys", "modified wilson", "modified jeffreys", "clopper-pearson", "arcsine", "logit", "witting", "pratt",
+#'   "midp", "lik", and "blaker".
+#' @return A matrix with 3 columns containing:
+#' \describe{
+#'   \item{est}{estimate of proportion difference.}
+#'   \item{lwrci}{lower end of the confidence interval.}
+#'   \item{upci}{upper end of the confidence interval.}
+#' }
 #'
 #' @keywords internal
-desctools_binomci <- function(x, n, conf.level = 0.95, sides = c(
-                                "two.sided", "left",
-                                "right"
-                              ), method = c(
+desctools_binomci <- function(x,
+                              n,
+                              conf.level = 0.95,
+                              sides = c("two.sided", "left", "right"),
+                              method = c(
                                 "wilson", "wald", "waldcc", "agresti-coull",
                                 "jeffreys", "modified wilson", "wilsoncc", "modified jeffreys",
                                 "clopper-pearson", "arcsine", "logit", "witting", "pratt",
                                 "midp", "lik", "blaker"
-                              ), rand = 123, tol = 1e-05) {
+                              ),
+                              rand = 123,
+                              tol = 1e-05) {
   if (missing(method)) {
     method <- "wilson"
   }
@@ -391,7 +397,7 @@ desctools_binomci <- function(x, n, conf.level = 0.95, sides = c(
     if (length(conf.level) != 1) {
       stop("'conf.level' has to be of length 1 (confidence level)")
     }
-    if (conf.level < 0.5 | conf.level > 1) {
+    if (conf.level < 0.5 || conf.level > 1) {
       stop("'conf.level' has to be in [0.5, 1]")
     }
     sides <- match.arg(sides, choices = c(

--- a/R/df_explicit_na.R
+++ b/R/df_explicit_na.R
@@ -12,7 +12,7 @@
 #'   with the `char_as_factor` or `logical_as_factor` options, the missing values will
 #'   be set as the last level.
 #'
-#' @param data (`data frame`)\cr data set.
+#' @param data (`data.frame`)\cr data set.
 #' @param omit_columns (`character`)\cr names of variables from `data` that should
 #'   not be modified by this function.
 #' @param char_as_factor (`flag`)\cr whether to convert character variables

--- a/R/estimate_proportion.R
+++ b/R/estimate_proportion.R
@@ -14,22 +14,19 @@ NULL
 #' @describeIn estimate_proportions statistics function estimating a
 #'   proportion along with its confidence interval.
 #'
-#' @param df (`logical` or `data.frame`)\cr
-#'   if only a logical vector is used, it indicates whether each subject is a
-#'   responder or not. `TRUE` represents a successful outcome. If a `data.frame`
-#'   is provided, also the `strata` variable names must be provided in
-#'   `variables` as a list element with the strata strings. In the case of
-#'   `data.frame`, the logical vector of responses must be indicated as a
-#'   variable name in `.var`.
-#' @param method (`string`) \cr
-#'   the method used to construct the confidence interval for proportion of
-#'   successful outcomes; one of `waldcc`, `wald`, `clopper-pearson`, `wilson`,
-#'   `wilsonc`, `strat_wilson`, `strat_wilsonc`, `agresti-coull` or `jeffreys`.
 #' @inheritParams prop_strat_wilson
+#' @param df (`logical` or `data.frame`)\cr if only a logical vector is used,
+#'   it indicates whether each subject is a responder or not. `TRUE` represents
+#'   a successful outcome. If a `data.frame` is provided, also the `strata` variable
+#'   names must be provided in `variables` as a list element with the strata strings.
+#'   In the case of `data.frame`, the logical vector of responses must be indicated as a
+#'   variable name in `.var`.
+#' @param method (`string`)\cr the method used to construct the confidence interval
+#'   for proportion of successful outcomes; one of `waldcc`, `wald`, `clopper-pearson`,
+#'   `wilson`, `wilsonc`, `strat_wilson`, `strat_wilsonc`, `agresti-coull` or `jeffreys`.
 #' @param long (`flag`)\cr a long description is required.
 #'
 #' @examples
-#'
 #' # Case with only logical vector.
 #' rsp_v <- c(1, 0, 1, 0, 1, 1, 0, 0)
 #' s_proportion(rsp_v)
@@ -216,18 +213,13 @@ prop_wilson <- function(rsp, conf_level, correct = FALSE) {
 #'   interval for unequal proportions as described in
 #'   \insertCite{Yan2010-jt;textual}{tern}
 #'
-#' @param strata (`factor`)\cr
-#'   with one level per stratum and same length as `rsp`.
-#' @param weights (`numeric` or `NULL`) \cr
-#'   weights for each level of the strata. If `NULL`, they are
-#'   estimated using the iterative algorithm proposed in
-#'   \insertCite{Yan2010-jt;textual}{tern} that minimizes the weighted squared
-#'   length of the confidence interval.
-#' @param max_iterations (`count`) \cr
-#'   maximum number of iterations for the iterative procedure used
+#' @param strata (`factor`)\cr variable with one level per stratum and same length as `rsp`.
+#' @param weights (`numeric` or `NULL`)\cr weights for each level of the strata. If `NULL`, they are
+#'   estimated using the iterative algorithm proposed in \insertCite{Yan2010-jt;textual}{tern} that
+#'   minimizes the weighted squared length of the confidence interval.
+#' @param max_iterations (`count`)\cr maximum number of iterations for the iterative procedure used
 #'   to find estimates of optimal weights.
-#' @param correct (`flag`)\cr
-#'   include the continuity correction. For further information, see for example
+#' @param correct (`flag`)\cr include the continuity correction. For further information, see for example
 #'   [stats::prop.test()].
 #'
 #' @examples
@@ -359,6 +351,7 @@ prop_clopper_pearson <- function(rsp,
 #' @describeIn h_proportions the Wald interval follows the usual
 #'   textbook definition for a single proportion confidence interval using the
 #'   normal approximation.
+#'
 #' @param correct (`flag`)\cr apply continuity correction.
 #'
 #' @examples
@@ -444,8 +437,7 @@ prop_jeffreys <- function(rsp,
 #' This is a helper function that describes the analysis in [s_proportion()].
 #'
 #' @inheritParams s_proportion
-#' @param long (`flag`)\cr
-#'   whether a long or a short (default) description is required.
+#' @param long (`flag`)\cr whether a long or a short (default) description is required.
 #'
 #' @return String describing the analysis.
 #'
@@ -514,19 +506,13 @@ strata_normal_quantile <- function(vars, weights, conf_level) {
 #' weighted squared length of the confidence interval.
 #'
 #' @inheritParams prop_strat_wilson
-#' @param vars (`numeric`) \cr
-#'   normalized proportions for each strata.
-#' @param strata_qnorm (`numeric`) \cr
-#'   initial estimation with identical weights of the quantiles.
-#' @param initial_weights (`numeric`) \cr
-#'   initial weights used to calculate `strata_qnorm`. This can be optimized in
-#'   the future if we need to estimate better initial weights.
-#' @param n_per_strata (`numeric`) \cr
-#'   number of elements in each strata.
-#' @param max_iterations (`count`) \cr
-#'   maximum number of iterations to be tried. Convergence is always checked.
-#' @param tol (`number`) \cr
-#'   tolerance threshold for convergence.
+#' @param vars (`numeric`)\cr normalized proportions for each strata.
+#' @param strata_qnorm (`numeric`)\cr initial estimation with identical weights of the quantiles.
+#' @param initial_weights (`numeric`)\cr initial weights used to calculate `strata_qnorm`. This can
+#'   be optimized in the future if we need to estimate better initial weights.
+#' @param n_per_strata (`numeric`)\cr number of elements in each strata.
+#' @param max_iterations (`count`)\cr maximum number of iterations to be tried. Convergence is always checked.
+#' @param tol (`number`)\cr tolerance threshold for convergence.
 #'
 #' @seealso For references and details see [prop_strat_wilson()].
 #'

--- a/R/fit_rsp_step.R
+++ b/R/fit_rsp_step.R
@@ -7,8 +7,10 @@
 #' where the first one is taken as reference and the estimated odds ratios are
 #' for the comparison of the second level vs. the first one.
 #'
-#' The (conditional) logistic regression model which is fit is:\cr
-#' `response ~ arm * poly(biomarker, degree) + covariates + strata(strata)`\cr
+#' The (conditional) logistic regression model which is fit is:
+#'
+#' `response ~ arm * poly(biomarker, degree) + covariates + strata(strata)`
+#'
 #' where `degree` is specified by `control_step()`.
 #' Note that for the default degree 0 the `biomarker` variable is not included in the model.
 #'
@@ -25,6 +27,7 @@
 #' @seealso [control_step()] and [control_logistic()] for the available
 #'   customization options.
 #' @export
+#'
 #' @examples
 #' # Testing dataset with just two treatment arms.
 #' library(survival)

--- a/R/fit_survival_step.R
+++ b/R/fit_survival_step.R
@@ -6,8 +6,10 @@
 #' variable must have exactly 2 levels, where the first one is taken as reference and the estimated
 #' hazard ratios are for the comparison of the second level vs. the first one.
 #'
-#' The model which is fit is:\cr
-#' `Surv(time, event) ~ arm * poly(biomarker, degree) + covariates + strata(strata)`\cr
+#' The model which is fit is:
+#'
+#' `Surv(time, event) ~ arm * poly(biomarker, degree) + covariates + strata(strata)`
+#'
 #' where `degree` is specified by `control_step()`.
 #' Note that for the default degree 0 the `biomarker` variable is not included in the model.
 #'
@@ -20,6 +22,7 @@
 #'   second part of the columns contain the estimates for the treatment arm comparison.
 #' @seealso [control_step()] and [control_coxph()] for the available customization options.
 #' @export
+#'
 #' @examples
 #' # Testing dataset with just two treatment arms.
 #' library(dplyr)

--- a/R/g_forest.R
+++ b/R/g_forest.R
@@ -11,29 +11,25 @@
 #'   `tbl` attribute `col_x`, otherwise needs to be manually specified.
 #' @param col_ci (`integer`)\cr column index with confidence intervals. By default tries
 #'   to get this from `tbl` attribute `col_ci`, otherwise needs to be manually specified.
-#' @param vline (`number`)\cr
-#'   x coordinate for vertical line, if `NULL` then the line is omitted.
-#' @param forest_header (`character`, length 2)\cr
-#'   text displayed to the left and right of `vline`, respectively.
+#' @param vline (`number`)\cr x coordinate for vertical line, if `NULL` then the line is omitted.
+#' @param forest_header (`character`, length 2)\cr text displayed to the left and right of `vline`, respectively.
 #'   If `vline = NULL` then `forest_header` needs to be `NULL` too.
 #'   By default tries to get this from `tbl` attribute `forest_header`.
 #' @param xlim (`numeric`)\cr limits for x axis.
 #' @param logx (`flag`)\cr show the x-values on logarithm scale.
 #' @param x_at (`numeric`)\cr x-tick locations, if `NULL` they get automatically chosen.
-#' @param width_row_names (`unit`)\cr
-#'  width for row names. If `NULL` the widths get automatically calculated. See [grid::unit()].
-#' @param width_columns (`unit`)\cr
-#'  widths for the table columns. If `NULL` the widths get automatically calculated. See [grid::unit()].
-#' @param width_forest (`unit`)\cr
-#'  width for the forest column. If `NULL` the widths get automatically calculated. See [grid::unit()].
-#' @param col_symbol_size (`integer`)\cr
-#'  column index from `tbl` containing data to be used to determine relative
-#'  size for estimator plot symbol. Typically, the symbol size is proportional to the
-#'  sample size used to calculate the estimator. If `NULL`, the same symbol
-#'  size is used for all subgroups. By default tries to get this from
-#'  `tbl` attribute `col_symbol_size`, otherwise needs to be manually specified.
+#' @param width_row_names (`unit`)\cr width for row names.
+#'   If `NULL` the widths get automatically calculated. See [grid::unit()].
+#' @param width_columns (`unit`)\cr widths for the table columns.
+#'   If `NULL` the widths get automatically calculated. See [grid::unit()].
+#' @param width_forest (`unit`)\cr width for the forest column.
+#'   If `NULL` the widths get automatically calculated. See [grid::unit()].
+#' @param col_symbol_size (`integer`)\cr column index from `tbl` containing data to be used
+#'   to determine relative size for estimator plot symbol. Typically, the symbol size is proportional
+#'   to the sample size used to calculate the estimator. If `NULL`, the same symbol size is used for all subgroups.
+#'   By default tries to get this from `tbl` attribute `col_symbol_size`, otherwise needs to be manually specified.
 #' @param col (`character`)\cr color(s).
-#' @return (`gtree`) object containing the forest plot and table
+#' @return `gtree` object containing the forest plot and table
 #' @export
 #'
 #' @examples

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -2,74 +2,61 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' Line plot with the optional table
+#' Line plot with the optional table.
 #'
-#' @param df (`data frame`) \cr data set containing all analysis variables.
-#' @param alt_counts_df (`data frame` or `NULL`) \cr
-#'  data set that will be used (only) to counts objects in strata.
-#' @param variables (named `character` vector) of variable names in `df` data set. Details are: \cr
-#' * `x`: x-axis variable.
-#' * `y`: y-axis variable.
-#' * `strata`: grouping variable, i.e. treatment arm. Can be `NA` to indicate lack of groups.
-#' * `paramcd`: the variable name for parameter's code. Used for y-axis label and plot's subtitle.
-#' Can be `NA` if paramcd is not to be added to the y-axis label or subtitle.
-#' * `y_unit`: variable with units of `y`. Used for y-axis label and plot's subtitle.
-#' Can be `NA` if y unit is not to be added to the y-axis label or subtitle.
-#' @param mid (`character` or `NULL`) \cr
-#' names of the statistics that will be plotted as midpoints.
-#' All the statistics indicated in `mid` variable must be present in the object returned by `sfun`,
-#' and be of a `double` or `numeric` type vector of length one.
-#' @param interval (`character` or `NULL`) \cr
-#' names of the statistics that will be plotted as intervals.
-#' All the statistics indicated in `interval` variable must be present in the object returned by `sfun`,
-#' and be of a `double` or `numeric` type vector of length two.
-#' @param whiskers (`character`) \cr
-#' names of the interval whiskers that will be plotted. Must match the `names` attribute of the
-#' `interval` element in the list returned by `sfun`.
-#' It is possible to specify one whisker only, lower or upper.
-#' @param table (`character` or `NULL`) \cr
-#' names of the statistics that will be displayed in the table below the plot.
-#' All the statistics indicated in `table` variable must be present in the object returned by `sfun`.
-#' @param sfun (`closure`) \cr the function to compute the values of required statistics.
-#' It must return a named `list` with atomic vectors.
-#' The names of the `list` elements refer to the names of the statistics
-#' and are used by `mid`, `interval`, `table`.
-#' It must be able to accept as input a vector with data for which statistics are computed.
+#' @param df (`data.frame`)\cr data set containing all analysis variables.
+#' @param alt_counts_df (`data.frame` or `NULL`)\cr data set that will be used (only) to counts objects in strata.
+#' @param variables (named `character` vector) of variable names in `df` data set. Details are:
+#'   * `x` (`character`)\cr name of x-axis variable.
+#'   * `y` (`character`)\cr name of y-axis variable.
+#'   * `strata` (`character`)\cr name of grouping variable, i.e. treatment arm. Can be `NA` to indicate lack of groups.
+#'   * `paramcd` (`character`)\cr name of the variable for parameter's code. Used for y-axis label and plot's subtitle.
+#'     Can be `NA` if paramcd is not to be added to the y-axis label or subtitle.
+#'   * `y_unit` (`character`)\cr name of variable with units of `y`. Used for y-axis label and plot's subtitle.
+#'     Can be `NA` if y unit is not to be added to the y-axis label or subtitle.
+#' @param mid (`character` or `NULL`)\cr names of the statistics that will be plotted as midpoints.
+#'   All the statistics indicated in `mid` variable must be present in the object returned by `sfun`,
+#'   and be of a `double` or `numeric` type vector of length one.
+#' @param interval (`character` or `NULL`)\cr names of the statistics that will be plotted as intervals.
+#'   All the statistics indicated in `interval` variable must be present in the object returned by `sfun`,
+#'   and be of a `double` or `numeric` type vector of length two.
+#' @param whiskers (`character`)\cr names of the interval whiskers that will be plotted. Must match the `names`
+#'   attribute of the `interval` element in the list returned by `sfun`. It is possible to specify one whisker only,
+#'   lower or upper.
+#' @param table (`character` or `NULL`)\cr names of the statistics that will be displayed in the table below the plot.
+#'   All the statistics indicated in `table` variable must be present in the object returned by `sfun`.
+#' @param sfun (`closure`)\cr the function to compute the values of required statistics. It must return a named `list`
+#'   with atomic vectors. The names of the `list` elements refer to the names of the statistics and are used by `mid`,
+#'   `interval`, `table`. It must be able to accept as input a vector with data for which statistics are computed.
 #' @param ... optional arguments to `sfun`.
-#' @param mid_type (`character` scalar) \cr
-#' controls the type of the `mid` plot, it can be point (`p`), line (`l`), or point and line (`pl`).
-#' @param mid_point_size (`integer` or `double`) \cr
-#' controls the font size of the point for `mid` plot.
-#' @param position (`character` or `call`) \cr
-#' geom element position adjustment, either as a string, or the result of a call to a position adjustment function.
-#' @param legend_title (`character` string) \cr legend title.
-#' @param legend_position (`character`) \cr
-#' the position of the plot legend (`none`, `left`, `right`, `bottom`, `top`, or two-element numeric vector).
-#' @param ggtheme (`theme`) \cr
-#' a graphical theme as provided by `ggplot2` to control outlook of the plot.
-#' @param y_lab (`character` scalar) \cr y-axis label.
-#' If it equals to `NULL`, then no label will be added.
-#' @param y_lab_add_paramcd (`logical` scalar) \cr
-#' should paramcd, i.e. `unique(df[[variables["paramcd"]]])` be added to the y-axis label `y_lab`?
-#' @param y_lab_add_unit (`logical` scalar) \cr
-#' should y unit, i.e. `unique(df[[variables["y_unit"]]])` be added to the y-axis label `y_lab`?
-#' @param title (`character` scalar) \cr plot title.
-#' @param subtitle (`character` scalar) \cr plot subtitle.
-#' @param subtitle_add_paramcd (`logical` scalar) \cr
-#' should paramcd, i.e. `unique(df[[variables["paramcd"]]])` be added to the plot's subtitle `subtitle`?
-#' @param subtitle_add_unit (`logical` scalar) \cr
-#' should y unit, i.e. `unique(df[[variables["y_unit"]]])` be added to the plot's subtitle `subtitle`?
-#' @param caption (`character` scalar) \cr optional caption below the plot.
-#' @param table_format (named `character` or `NULL`) \cr
-#' format patterns for descriptive statistics used in the (optional) table appended to the plot.
-#' It is passed directly to the `h_format_row` function through the `format` parameter.
-#' Names of `table_format` must match the names of statistics returned by `sfun` function.
-#' @param table_labels (named `character` or `NULL`) \cr
-#' labels for descriptive statistics used in the (optional) table appended to the plot.
-#' Names of `table_labels` must match the names of statistics returned by `sfun` function.
-#' @param table_font_size (`integer` or `double`) \cr
-#' controls the font size of values in the table.
-#' @param newpage (`logical` scalar) \cr should plot be drawn on new page?
+#' @param mid_type (`character`)\cr controls the type of the `mid` plot, it can be point (`p`), line (`l`),
+#'   or point and line (`pl`).
+#' @param mid_point_size (`integer` or `double`)\cr controls the font size of the point for `mid` plot.
+#' @param position (`character` or `call`)\cr geom element position adjustment, either as a string, or the result of
+#'   a call to a position adjustment function.
+#' @param legend_title (`character` string)\cr legend title.
+#' @param legend_position (`character`)\cr the position of the plot legend (`none`, `left`, `right`, `bottom`, `top`,
+#'   or two-element numeric vector).
+#' @param ggtheme (`theme`)\cr a graphical theme as provided by `ggplot2` to control styling of the plot.
+#' @param y_lab (`character`)\cr y-axis label. If equal to `NULL`, then no label will be added.
+#' @param y_lab_add_paramcd (`logical`)\cr should paramcd, i.e. `unique(df[[variables["paramcd"]]])` be added to the
+#'   y-axis label `y_lab`?
+#' @param y_lab_add_unit (`logical`)\cr should y unit, i.e. `unique(df[[variables["y_unit"]]])` be added to the y-axis
+#'   label `y_lab`?
+#' @param title (`character`)\cr plot title.
+#' @param subtitle (`character`)\cr plot subtitle.
+#' @param subtitle_add_paramcd (`logical`)\cr should paramcd, i.e. `unique(df[[variables["paramcd"]]])` be added to
+#'   the plot's subtitle `subtitle`?
+#' @param subtitle_add_unit (`logical`)\cr should y unit, i.e. `unique(df[[variables["y_unit"]]])` be added to the
+#'   plot's subtitle `subtitle`?
+#' @param caption (`character`)\cr optional caption below the plot.
+#' @param table_format (named `character` or `NULL`)\cr format patterns for descriptive statistics used in the
+#'   (optional) table appended to the plot. It is passed directly to the `h_format_row` function through the `format`
+#'   parameter. Names of `table_format` must match the names of statistics returned by `sfun` function.
+#' @param table_labels (named `character` or `NULL`)\cr labels for descriptive statistics used in the (optional) table
+#'   appended to the plot. Names of `table_labels` must match the names of statistics returned by `sfun` function.
+#' @param table_font_size (`integer` or `double`)\cr controls the font size of values in the table.
+#' @param newpage (`logical`)\cr should plot be drawn on new page?
 #' @param col (`character`)\cr colors.
 #'
 #' @author Wojciech Wojciak wojciech.wojciak@contractors.roche.com
@@ -423,13 +410,13 @@ g_lineplot <- function(df, # nolint
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' @param x (named `list`) \cr list of numerical values to be formatted and optionally labeled.
+#' @param x (named `list`)\cr list of numerical values to be formatted and optionally labeled.
 #' Elements of `x` must be `numeric` vectors.
-#' @param format (named `character` or `NULL`) \cr
+#' @param format (named `character` or `NULL`)\cr
 #' format patterns for `x`. Names of the `format` must match the names of `x`.
 #' This parameter is passed directly to the `rtables::format_rcell`
 #' function through the `format` parameter.
-#' @param labels (named `character` or `NULL`) \cr
+#' @param labels (named `character` or `NULL`)\cr
 #' optional labels for `x`. Names of the `labels` must match the names of `x`.
 #' When a label is not specified for an element of `x`,
 #' then this function tries to use `label` or `names` (in this order) attribute of that element
@@ -489,11 +476,11 @@ h_format_row <- function(x, format, labels = NULL) {
 #' Default values for `variables` parameter in `g_lineplot` function.
 #' A variable's default value can be overwritten for any variable.
 #'
-#' @param x (`character` scalar) x variable name. \cr
-#' @param y (`character` scalar) y variable name. \cr
-#' @param strata (`character` scalar or `NA`) strata variable name. \cr
-#' @param paramcd (`character` scalar or `NA`) paramcd variable name. \cr
-#' @param y_unit (`character` scalar or `NA`) y_unit variable name. \cr
+#' @param x (`character`)\cr x variable name.
+#' @param y (`character`)\cr y variable name.
+#' @param strata (`character` or `NA`)\cr strata variable name.
+#' @param paramcd (`character` or `NA`)\cr paramcd variable name.
+#' @param y_unit (`character` or `NA`)\cr y_unit variable name.
 #'
 #' @return A named character vector with names of variables.
 #'

--- a/R/g_waterfall.R
+++ b/R/g_waterfall.R
@@ -5,23 +5,15 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' @param height (\code{numeric} vector)\cr
-#'   Contains values to be plotted as the waterfall bars
-#' @param id (vector)\cr
-#'   Contains of IDs used as the x-axis label for the waterfall bars
+#' @param height (`numeric``)\cr vector containing values to be plotted as the waterfall bars.
+#' @param id (`character`)\cr vector containing IDs to use as the x-axis label for the waterfall bars.
 #' @param col (`character`)\cr colors.
-#' @param col_var (`factor`, `character` or `NULL`)\cr
-#'   Categorical variable for bar coloring. `NULL` by default.
-#' @param xlab (\code{character} value)\cr
-#'   x label. Default is \code{ID}.
-#' @param ylab (\code{character} value)\cr
-#'   y label. Default is \code{Value}.
-#' @param title (\code{character} value)\cr
-#'   Text to be displayed as plot title.
-#' @param col_legend_title (\code{character} value)\cr
-#'   Text to be displayed as legend title.
-#' @return (\code{ggplot} object)\cr
-#'   Waterfall plot
+#' @param col_var (`factor`, `character` or `NULL`)\cr categorical variable for bar coloring. `NULL` by default.
+#' @param xlab (`character`)\cr x label. Default is `"ID"`.
+#' @param ylab (`character`)\cr y label. Default is `"Value"`.
+#' @param title (`character`)\cr text to be displayed as plot title.
+#' @param col_legend_title (`character`)\cr text to be displayed as legend title.
+#' @return (`ggplot` object)\cr waterfall plot.
 #' @template author_song24
 #'
 #' @export

--- a/R/h_adsl_adlb_merge_using_worst_flag.R
+++ b/R/h_adsl_adlb_merge_using_worst_flag.R
@@ -5,26 +5,25 @@
 #' Helper function that merges `ADSL` and `ADLB` datasets so that missing lab test records are inserted in the
 #' output dataset.
 #'
-#' @param adsl (`data frame`) `ADSL` dataframe
-#' @param adlb (`data frame`) `ADLB` dataframe
-#' @param worst_flag (named `vector`)
-#' Worst post-baseline lab flag variable
-#' @param by_visit (`logical`) defaults to `FALSE` to generate worst grade per patient.
-#' If worst grade per patient per visit is specified for `worst_flag`, then
-#' `by_visit` should be `TRUE` to generate worst grade patient per visit.
-#' @param no_fillin_visits (named `character`)
-#' Visits that are not considered for post-baseline worst toxicity grade. Defaults to `c("SCREENING", "BASELINE")`.
+#' @param adsl (`data.frame`)\cr `ADSL` dataframe.
+#' @param adlb (`data.frame`)\cr `ADLB` dataframe.
+#' @param worst_flag (named `vector`)\cr Worst post-baseline lab flag variable.
+#' @param by_visit (`logical`)\cr defaults to `FALSE` to generate worst grade per patient.
+#'   If worst grade per patient per visit is specified for `worst_flag`, then
+#'   `by_visit` should be `TRUE` to generate worst grade patient per visit.
+#' @param no_fillin_visits (named `character`)\cr Visits that are not considered for post-baseline worst toxicity
+#'   grade. Defaults to `c("SCREENING", "BASELINE")`.
 #'
 #' @return `df` containing variables shared between `adlb` and `adsl` along with variables relevant for analysis:
-#' `PARAM`, `PARAMCD`, `ATOXGR`, and `BTOXGR`.  Optionally `AVISIT`, `AVISITN` are included when `by_visit = TRUE` and
-#' `no_fillin_visits = c("SCREENING", "BASELINE")`.
+#'   `PARAM`, `PARAMCD`, `ATOXGR`, and `BTOXGR`.  Optionally `AVISIT`, `AVISITN` are included when `by_visit = TRUE`
+#'   and `no_fillin_visits = c("SCREENING", "BASELINE")`.
 #'
 #' @export
 #'
 #' @details In the result data missing records will be created for the following situations:
-#'  * patients who are present in `adsl` but have no lab data in `adlb` (both baseline and post-baseline)
-#'  * patients who do not have any post-baseline lab values
-#'  * patients without any post-baseline values flagged as the worst
+#'   * Patients who are present in `adsl` but have no lab data in `adlb` (both baseline and post-baseline).
+#'   * Patients who do not have any post-baseline lab values.
+#'   * Patients without any post-baseline values flagged as the worst.
 #'
 #' @examples
 #' # `h_adsl_adlb_merge_using_worst_flag`

--- a/R/h_map_for_count_abnormal.R
+++ b/R/h_map_for_count_abnormal.R
@@ -6,7 +6,7 @@
 #' `trim_levels_to_map` split function. Based on different method, the map is constructed differently.
 #'
 #' @inheritParams argument_convention
-#' @param abnormal (`named list`)\cr identifying the abnormal range level(s) in `df`. Based on the levels of abnormality
+#' @param abnormal (named `list`)\cr identifying the abnormal range level(s) in `df`. Based on the levels of abnormality
 #' of the input dataset, it can be something like `list(Low = "LOW LOW", High = "HIGH HIGH")` or
 #' `abnormal = list(Low = "LOW", High = "HIGH"))`
 #' @param method (`string`)\cr indicates how the returned map will be constructed. Can be either `"default"` or

--- a/R/h_response_subgroups.R
+++ b/R/h_response_subgroups.R
@@ -138,9 +138,9 @@ h_proportion_subgroups_df <- function(variables,
 
 #' @describeIn h_response_subgroups helper to prepare a data frame with estimates of
 #'   the odds ratio between a treatment and a control arm.
+#'
 #' @inheritParams response_subgroups
-#' @param strata_data (`factor`, `data.frame` or `NULL`)\cr
-#'   required if stratified analysis is performed.
+#' @param strata_data (`factor`, `data.frame` or `NULL`)\cr required if stratified analysis is performed.
 #' @export
 #'
 #' @examples

--- a/R/h_stack_by_baskets.R
+++ b/R/h_stack_by_baskets.R
@@ -14,7 +14,7 @@
 #' @param smq_varlabel (`string`)\cr a label for the new variable created.
 #' @param keys (`character`)\cr names of the key variables to be returned
 #' along with the new variable created.
-#' @param aag_summary (`data frame`)\cr containing the `SMQ` baskets
+#' @param aag_summary (`data.frame`)\cr containing the `SMQ` baskets
 #' and the levels of interest for the final `SMQ` variable. This is useful when
 #' there are some levels of interest that are not observed in the `df` dataset.
 #' The two columns of this dataset should be named `basket` and `basket_name`.

--- a/R/h_step.R
+++ b/R/h_step.R
@@ -15,8 +15,9 @@ NULL
 #' @describeIn h_step creates the windows for STEP, based on the control settings
 #'   provided. Returns a list containing the window-selection matrix `sel`
 #'   and the interval information matrix `interval`.
-#' @param x (`numeric`) biomarker value(s) to use (without `NA`).
-#' @param control (named `list`) from `control_step()`.
+#'
+#' @param x (`numeric`)\cr biomarker value(s) to use (without `NA`).
+#' @param control (named `list`)\cr output from `control_step()`.
 #'
 #' @export
 h_step_window <- function(x,

--- a/R/h_survival_duration_subgroups.R
+++ b/R/h_survival_duration_subgroups.R
@@ -169,8 +169,8 @@ h_survtime_subgroups_df <- function(variables,
 
 #' @describeIn h_survival_duration_subgroups helper to prepare a data frame with estimates of
 #'   treatment hazard ratio.
-#' @param strata_data (`factor`, `data.frame` or `NULL`)\cr
-#'   required if stratified analysis is performed.
+#'
+#' @param strata_data (`factor`, `data.frame` or `NULL`)\cr required if stratified analysis is performed.
 #'
 #' @examples
 #' # Extract hazard ratio for one group.
@@ -377,7 +377,7 @@ h_coxph_subgroups_df <- function(variables,
 #' @details Main functionality is to prepare data for use in forest plot layouts.
 #'
 #' @inheritParams survival_duration_subgroups
-#' @param data (`data frame`)\cr dataset to split.
+#' @param data (`data.frame`)\cr dataset to split.
 #' @param subgroups (`character`)\cr names of factor variables from `data` used to create subsets.
 #'   Unused levels not present in `data` are dropped. Note that the order in this vector
 #'   determines the order in the downstream table.

--- a/R/incidence_rate.R
+++ b/R/incidence_rate.R
@@ -6,17 +6,17 @@
 #' as incidence rate. Primary analysis variable is the person-years at risk.
 #'
 #' @inheritParams argument_convention
-#' @param control (`list`) \cr parameters for estimation details, specified by using
-#'   the helper function [control_incidence_rate()]. Possible parameter options are: \cr
-#' * `conf_level`: (`proportion`) \cr confidence level for the estimated incidence rate.
-#' * `conf_type`: (`string`) \cr `normal` (default), `normal_log`, `exact`, or `byar`
-#'   for confidence interval type.
-#' * `time_unit_input`: (`string`) \cr `day`, `week`, `month`, or `year` (default)
-#'   indicating time unit for data input.
-#' * `time_unit_output`: (`numeric`) \cr time unit for desired output (in person-years).
-#' @param person_years (`numeric`) \cr total person-years at risk.
-#' @param alpha (`numeric`) \cr two-sided alpha-level for confidence interval.
-#' @param n_events (`integer`) \cr number of events observed.
+#' @param control (`list`)\cr parameters for estimation details, specified by using
+#'   the helper function [control_incidence_rate()]. Possible parameter options are:
+#'   * `conf_level` (`proportion`)\cr confidence level for the estimated incidence rate.
+#'   * `conf_type` (`string`)\cr `normal` (default), `normal_log`, `exact`, or `byar`
+#'     for confidence interval type.
+#'   * `time_unit_input` (`string`)\cr `day`, `week`, `month`, or `year` (default)
+#'     indicating time unit for data input.
+#'   * `time_unit_output` (`numeric`)\cr time unit for desired output (in person-years).
+#' @param person_years (`numeric`)\cr total person-years at risk.
+#' @param alpha (`numeric`)\cr two-sided alpha-level for confidence interval.
+#' @param n_events (`integer`)\cr number of events observed.
 #'
 #' @seealso [control_incidence_rate()] and helper functions [h_incidence_rate].
 #'
@@ -27,13 +27,14 @@ NULL
 #'   associated confidence interval.
 #'
 #' @return The statistics are:
-#'   * `person_years`: total person-years at risk
-#'   * `n_events`: total number of events observed
-#'   * `rate`: estimated incidence rate
-#'   * `rate_ci`: confidence interval for the incidence rate
+#' \describe{
+#'   \item{person_years}{total person-years at risk}
+#'   \item{n_events}{total number of events observed}
+#'   \item{rate}{estimated incidence rate}
+#'   \item{rate_ci}{confidence interval for the incidence rate}
+#' }
 #'
 #' @examples
-#'
 #' library(dplyr)
 #'
 #' df <- data.frame(
@@ -180,17 +181,18 @@ estimate_incidence_rate <- function(lyt,
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' @param control (`list`) \cr parameters for estimation details, specified by using
-#'   the helper function [control_incidence_rate()]. Possible parameter options are: \cr
-#' * `conf_level`: (`proportion`) \cr confidence level for the estimated incidence rate.
-#' * `conf_type`: (`string`) \cr `normal` (default), `normal_log`, `exact`, or `byar`
-#'   for confidence interval type.
-#' * `time_unit_input`: (`string`) \cr `day`, `week`, `month`, or `year` (default)
-#'   indicating time unit for data input.
-#' * `time_unit_output`: (`numeric`) \cr time unit for desired output (in person-years).
-#' @param person_years (`numeric`) \cr total person-years at risk.
-#' @param alpha (`numeric`) \cr two-sided alpha-level for confidence interval.
-#' @param n_events (`integer`) \cr number of events observed.
+#' @param control (`list`)\cr parameters for estimation details, specified by using
+#'   the helper function [control_incidence_rate()]. Possible parameter options are:
+#'   * `conf_level`: (`proportion`)\cr confidence level for the estimated incidence rate.
+#'   * `conf_type`: (`string`)\cr `normal` (default), `normal_log`, `exact`, or `byar`
+#'     for confidence interval type.
+#'   * `time_unit_input`: (`string`)\cr `day`, `week`, `month`, or `year` (default)
+#'     indicating time unit for data input.
+#'   * `time_unit_output`: (`numeric`)\cr time unit for desired output (in person-years).
+#'
+#' @param person_years (`numeric`)\cr total person-years at risk.
+#' @param alpha (`numeric`)\cr two-sided alpha-level for confidence interval.
+#' @param n_events (`integer`)\cr number of events observed.
 #'
 #' @seealso [incidence_rate]
 #'

--- a/R/individual_patient_plot.R
+++ b/R/individual_patient_plot.R
@@ -23,7 +23,7 @@
 #' plots. Must be one of "all_in_one", "split_by_max_obs", "separate_by_obs".
 #' @param max_obs_per_plot (`count`)\cr Number of observations to be plotted on one
 #' plot. Ignored when `plotting_choices` is not "separate_by_obs".
-#' @param caption (`character` scalar) \cr optional caption below the plot.
+#' @param caption (`character` scalar)\cr optional caption below the plot.
 #' @param col (`character`)\cr lines colors.
 #'
 #' @seealso Relevant helper function [h_g_ipp()].

--- a/R/kaplan_meier_plot.R
+++ b/R/kaplan_meier_plot.R
@@ -2,25 +2,22 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' @param df (`data frame`)\cr data set containing all analysis variables.
-#' @param variables (named `list`) of variable names. Details are: \cr
-#' * `tte`: variable indicating time-to-event duration values (`numeric`).
-#' * `is_event`: event variable (`logical`) \cr `TRUE` if event, `FALSE` if time to event is censored.
-#' * `arm`: the treatment group variable (`factor`).
-#' * `strat`: (`character` or `NULL`) variable names indicating stratification factors.
-#' @param control_surv a (`list`) of parameters for comparison details, specified by using \cr
-#'    the helper function [`control_surv_timepoint`]. Some possible parameter options are: \cr
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for survival rate.
-#' * `conf_type`: (`string`) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-#'    see more in [survival::survfit()]. Note that the option "none" is no longer supported.
+#' @param df (`data.frame`)\cr data set containing all analysis variables.
+#' @param variables (named `list`)\cr variable names. Details are:
+#'   * `tte` (`numeric`)\cr variable indicating time-to-event duration values.
+#'   * `is_event` (`logical`)\cr event variable. `TRUE` if event, `FALSE` if time to event is censored.
+#'   * `arm` (`factor`)\cr the treatment group variable.
+#'   * `strat` (`character` or `NULL`)\cr variable names indicating stratification factors.
+#' @param control_surv (`list`)\cr parameters for comparison details, specified by using
+#'   the helper function [`control_surv_timepoint`]. Some possible parameter options are:
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for survival rate.
+#'   * `conf_type` (`string`)\cr "plain" (default), "log", "log-log" for confidence interval type,
+#'     see more in [survival::survfit()]. Note that the option "none" is no longer supported.
 #' @param data (`data.frame`)\cr survival data as pre-processed by `h_data_plot`.
-#' @param xticks (`numeric`, `number`, or `NULL`)\cr
-#'   numeric vector of ticks or single number with spacing
-#'   between ticks on the x axis.
-#'   If `NULL` (default), [labeling::extended()] is used to determine
+#' @param xticks (`numeric`, `number`, or `NULL`)\cr numeric vector of ticks or single number with spacing
+#'   between ticks on the x axis. If `NULL` (default), [labeling::extended()] is used to determine
 #'   an optimal tick position on the x axis.
-#' @param yval (`string`)\cr value of y-axis. Should be either
-#'   `Survival` (default) or `Failure` probability.
+#' @param yval (`string`)\cr value of y-axis. Options are `Survival` (default) and `Failure` probability.
 #' @param censor_show (`flag`)\cr whether to show censored.
 #' @param xlab (`string`)\cr label of x-axis.
 #' @param ylab (`string`)\cr label of y-axis.
@@ -34,36 +31,32 @@
 #'   to number of strata from [survival::survfit()].
 #' @param pch (`numeric`, `string`)\cr value or character of points symbol to indicate censored cases.
 #' @param size (`numeric`)\cr size of censored point, a class of `unit`.
-#' @param max_time (`numeric`)\cr maximum value to show on X axis.
-#' Only data values less than or up to to this threshold value will be plotted.(`NULL` for
-#'    default)
-#' @param font_size (`number`) \cr font size to be used.
+#' @param max_time (`numeric`)\cr maximum value to show on X axis. Only data values less than or up to
+#'   this threshold value will be plotted (defaults to `NULL`).
+#' @param font_size (`number`)\cr font size to be used.
 #' @param ci_ribbon (`flag`)\cr draw the confidence interval around the Kaplan-Meier curve.
-#' @param ggtheme (`theme`)\cr a graphical theme as provided by `ggplot2` to
-#'   control outlook of the Kaplan-Meier curve.
-#' @param annot_at_risk (`flag`)\cr compute and add the annotation table
-#'   reporting the number of patient at risk matching the main grid of the
-#'   Kaplan-Meier curve.
-#' @param annot_surv_med (`flag`)\cr compute and add the annotation table
-#'   on the Kaplan-Meier curve estimating the median survival time per group.
+#' @param ggtheme (`theme`)\cr a graphical theme as provided by `ggplot2` to control outlook of the Kaplan-Meier curve.
+#' @param annot_at_risk (`flag`)\cr compute and add the annotation table reporting the number of patient at risk
+#'   matching the main grid of the Kaplan-Meier curve.
+#' @param annot_surv_med (`flag`)\cr compute and add the annotation table on the Kaplan-Meier curve estimating the
+#'   median survival time per group.
 #' @param annot_coxph (`flag`)\cr add the annotation table from a [survival::coxph()] model.
 #' @param annot_stats (`string`)\cr statistics annotations to add to the plot. Options are
 #'   `median` (median survival follow-up time) and `min` (minimum survival follow-up time).
 #' @param annot_stats_vlines (`flag`)\cr add vertical lines corresponding to each of the statistics
 #'   specified by `annot_stats`. If `annot_stats` is `NULL` no lines will be added.
-#' @param control_coxph_pw (`list`) \cr parameters for comparison details, specified by using \cr
-#'    the helper function [control_coxph()]. Some possible parameter options are: \cr
-#' * `pval_method`: (`string`) \cr p-value method for testing hazard ratio = 1.
-#'   Default method is "log-rank", can also be set to "wald" or "likelihood".
-#' * `ties`: (`string`) \cr specifying the method for tie handling. Default is "efron",
-#'   can also be set to "breslow" or "exact". See more in [survival::coxph()]
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for HR.
-#' @param position_coxph `numeric` \cr x and y positions for plotting [survival::coxph()] model.
-#' @param position_surv_med `numeric` \cr x and y positions for plotting annotation table
-#'    estimating median survival time per group
+#' @param control_coxph_pw (`list`)\cr parameters for comparison details, specified by using
+#'   the helper function [control_coxph()]. Some possible parameter options are:
+#'   * `pval_method` (`string`)\cr p-value method for testing hazard ratio = 1.
+#'     Default method is "log-rank", can also be set to "wald" or "likelihood".
+#'   * `ties` (`string`)\cr method for tie handling. Default is "efron",
+#'     can also be set to "breslow" or "exact". See more in [survival::coxph()]
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for HR.
+#' @param position_coxph (`numeric`)\cr x and y positions for plotting [survival::coxph()] model.
+#' @param position_surv_med (`numeric`)\cr x and y positions for plotting annotation table estimating median survival
+#'   time per group.
 #'
 #' @name kaplan_meier
-#'
 NULL
 
 #' Kaplan-Meier Plot
@@ -470,7 +463,7 @@ g_km <- function(df,
 #'
 #' @inheritParams kaplan_meier
 #' @param fit_km (`survfit`)\cr result of [survival::survfit()].
-#' @param armval (`string`) \cr used as strata name when treatment arm
+#' @param armval (`string`)\cr used as strata name when treatment arm
 #' variable only has one level. Default is "All".
 #' @examples
 #' \dontrun{

--- a/R/logistic_regression.R
+++ b/R/logistic_regression.R
@@ -101,25 +101,22 @@ summarize_logistic <- function(lyt,
 #' Fit a (conditional) logistic regression model.
 #'
 #' @inheritParams argument_convention
-#' @param data (`data frame`)\cr the data frame on which the model was fit.
+#' @param data (`data.frame`)\cr the data frame on which the model was fit.
 #' @param response_definition (`string`)\cr the definition of what an event is in terms of `response`.
 #'   This will be used when fitting the (conditional) logistic regression model on the left hand
 #'   side of the formula.
 #'
 #' @section Model Specification:
 #'
-#' The `variables` list needs to include the following elements:\cr
-#' - `arm`: usual treatment arm variable name.
-#' - `response`: the response arm variable name. Usually this is a 0/1 variable.
-#' - `covariates`: this is either `NULL` (no covariates) or
-#'      a character vector of covariate variable names.
-#' - `interaction`: this is either `NULL` (no interaction) or a string of a single
-#'      covariate variable name already included in `covariates`. Then the interaction
-#'      with the treatment arm is included in the model.
-#'
-#' @details Note this function may hang or error for certain datasets when an old version of the
-#'   survival package (< 3.2-13) is used.
-#' @export
+#' The `variables` list needs to include the following elements:
+#' \describe{
+#'   \item{arm}{treatment arm variable name.}
+#'   \item{response}{the response arm variable name. Usually this is a 0/1 variable.}
+#'   \item{covariates}{this is either `NULL` (no covariates) or a character vector of covariate variable names.}
+#'   \item{interaction}{this is either `NULL` (no interaction) or a string of a single covariate variable name already
+#'     included in `covariates`. Then the interaction with the treatment arm is included in the model.
+#'   }
+#' }
 #'
 #' @examples
 #' library(dplyr)
@@ -150,6 +147,8 @@ summarize_logistic <- function(lyt,
 #'     interaction = "AGE"
 #'   )
 #' )
+#'
+#' @export
 fit_logistic <- function(data,
                          variables = list(
                            response = "Response",

--- a/R/odds_ratio.R
+++ b/R/odds_ratio.R
@@ -205,8 +205,8 @@ estimate_odds_ratio <- function(lyt,
 #' Functions to calculate odds ratios in [estimate_odds_ratio()].
 #'
 #' @inheritParams argument_convention
-#' @param data (`data frame`)\cr
-#'   with at least the variables `rsp`, `grp`, and in addition `strata` for [or_clogit()].
+#' @param data (`data.frame`)\cr data frame containing at least the variables `rsp` and `grp`, and optionally
+#'   `strata` for [or_clogit()].
 #'
 #' @seealso [odds_ratio]
 #'

--- a/R/prop_diff.R
+++ b/R/prop_diff.R
@@ -11,9 +11,9 @@ NULL
 
 #' @describeIn prop_diff Statistics function estimating the difference
 #'   in terms of responder proportion.
-#' @param method (`string`)\cr
-#'   the method used for the confidence interval estimation.
+#'
 #' @inheritParams prop_diff_strat_nc
+#' @param method (`string`)\cr the method used for the confidence interval estimation.
 #'
 #' @examples
 #' # Summary
@@ -236,8 +236,7 @@ check_diff_prop_ci <- function(rsp,
 #' `s_proportion_diff`.
 #'
 #' @inheritParams s_proportion_diff
-#' @param long (`logical`)\cr
-#'   Whether a long or a short (default) description is required.
+#' @param long (`logical`)\cr Whether a long or a short (default) description is required.
 #' @return String describing the analysis.
 #' @seealso [prop_diff]
 #'
@@ -277,8 +276,7 @@ d_proportion_diff <- function(conf_level,
 #'
 #' @inheritParams argument_convention
 #' @inheritParams prop_diff
-#' @param grp (`factor`)\cr
-#'   vector assigning observations to one out of two groups
+#' @param grp (`factor`)\cr vector assigning observations to one out of two groups
 #'   (e.g. reference and treatment group).
 #'
 #' @seealso [prop_diff()] for implementation of these helper functions.
@@ -291,9 +289,8 @@ NULL
 #'   approximation. It is possible to include a continuity correction for Wald's
 #'   interval.
 #'
-#' @param correct `logical`\cr
-#'   include the continuity correction. For further information, see for example
-#'   [stats::prop.test()].
+#' @param correct `logical`\cr include the continuity correction. For further
+#'   information, see [stats::prop.test()].
 #'
 #' @examples
 #' # Wald confidence interval
@@ -420,13 +417,12 @@ prop_diff_nc <- function(rsp,
 
 
 #' @describeIn h_prop_diff Calculates the weighted difference.
-#'     This is defined as the difference in response rates between the
-#'     experimental treatment group and the control treatment group, adjusted
-#'     for stratification factors by applying Cochran-Mantel-Haenszel (CMH)
-#'     weights. For the CMH chi-squared test, use [stats::mantelhaen.test()].
+#'   This is defined as the difference in response rates between the
+#'   experimental treatment group and the control treatment group, adjusted
+#'   for stratification factors by applying Cochran-Mantel-Haenszel (CMH)
+#'   weights. For the CMH chi-squared test, use [stats::mantelhaen.test()].
 #'
-#' @param strata (`factor`)\cr
-#'   with one level per stratum and same length as `rsp`.
+#' @param strata (`factor`)\cr variable with one level per stratum and same length as `rsp`.
 #'
 #' @examples
 #' # Cochran-Mantel-Haenszel confidence interval
@@ -518,11 +514,9 @@ prop_diff_cmh <- function(rsp,
 #'   heuristic proposed in [prop_strat_wilson()] or from CMH-derived weights
 #'   (see [prop_diff_cmh()]).
 #'
-#' @param strata (`factor`)\cr
-#'   with one level per stratum and same length as `rsp`.
-#' @param weights_method (`string`) \cr
-#'   it can be one of `c("cmh", "heuristic")` and directs the way weights are
-#'   estimated.
+#' @param strata (`factor`)\cr variable with one level per stratum and same length as `rsp`.
+#' @param weights_method (`string`)\cr weights method. Can be either `"cmh"` or `"heuristic"`
+#'   and directs the way weights are estimated.
 #'
 #' @examples
 #' # Stratified Newcombe confidence interval

--- a/R/prop_diff_test.R
+++ b/R/prop_diff_test.R
@@ -5,9 +5,8 @@
 #' Various tests were implemented to test the difference between two
 #' proportions.
 #'
-#' @param tbl (`matrix`)\cr
-#'   with two groups in rows and the binary response (`TRUE`/`FALSE`) in
-#'   columns.
+#' @param tbl (`matrix`)\cr matrix with two groups in rows and the binary response
+#'   (`TRUE`/`FALSE`) in columns.
 #' @seealso [h_prop_diff_test]
 #'
 #' @name prop_diff_test
@@ -18,8 +17,7 @@ NULL
 #'  between two proportions.
 #'
 #' @inheritParams argument_convention
-#' @param method (`string`)\cr
-#'   one of (`chisq`, `cmh`, `fisher`, `schouten`; specifies the test used
+#' @param method (`string`)\cr one of `chisq`, `cmh`, `fisher`, or `schouten`; specifies the test used
 #'   to calculate the p-value.
 #'
 #' @return Named `list` with a single item `pval` with an attribute `label`
@@ -189,9 +187,8 @@ test_proportion_diff <- function(lyt,
 #' Helper functions to implement various tests on the difference between two
 #' proportions.
 #'
-#' @param tbl (`matrix`)\cr
-#'   with two groups in rows and the binary response (`TRUE`/`FALSE`) in
-#'   columns.
+#' @param tbl (`matrix`)\cr matrix with two groups in rows and the binary response
+#'   (`TRUE`/`FALSE`) in columns.
 #'
 #' @seealso [prop_diff_test())] for implementation of these helper functions.
 #'
@@ -234,9 +231,9 @@ prop_chisq <- function(tbl) {
 #' @describeIn h_prop_diff_test performs stratified Cochran-Mantel-Haenszel test.
 #'   Internally calls [stats::mantelhaen.test()]. Note that strata with less than two observations
 #'   are automatically discarded.
-#' @param ary (`array`, 3 dimensions)\cr
-#'   with two groups in rows, the binary response (`TRUE`/`FALSE`) in
-#'   columns, the strata in the third dimension.
+#'
+#' @param ary (`array`, 3 dimensions)\cr array with two groups in rows, the binary response
+#'   (`TRUE`/`FALSE`) in columns, and the strata in the third dimension.
 #'
 #' @examples
 #' # Stratified proportion difference test

--- a/R/response_subgroups.R
+++ b/R/response_subgroups.R
@@ -8,15 +8,13 @@
 #'   the required statistics. Tables typically used as part of forest plot.
 #'
 #' @inheritParams argument_convention
-#' @param data (`data frame`)\cr the dataset containing the variables to summarize.
+#' @param data (`data.frame`)\cr the dataset containing the variables to summarize.
 #' @param groups_lists (named `list` of `list`)\cr optionally contains for each `subgroups` variable a
 #'   list, which specifies the new group levels via the names and the
 #'   levels that belong to it in the character vectors that are elements of the list.
 #' @param label_all (`string`)\cr label for the total population analysis.
-#' @param method (`string`)\cr
-#'   specifies the test used to calculate the p-value for the difference between
-#'   two proportions. For options, see [s_test_proportion_diff()]. Default is `NULL`
-#'   so no test is performed.
+#' @param method (`string`)\cr specifies the test used to calculate the p-value for the difference between
+#'   two proportions. For options, see [s_test_proportion_diff()]. Default is `NULL` so no test is performed.
 #' @name response_subgroups
 #' @seealso [extract_rsp_subgroups()]
 #'

--- a/R/summarize_ancova.R
+++ b/R/summarize_ancova.R
@@ -8,22 +8,23 @@
 #' @name summarize_ancova
 NULL
 
-#' Helper Function to Return Results of a Linear Model.
+#' Helper Function to Return Results of a Linear Model
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
 #' @inheritParams argument_convention
-#' @param .df_row (`data frame`)\cr data set that includes all the variables that are called
+#' @param .df_row (`data.frame`)\cr data set that includes all the variables that are called
 #'   in `.var` and `variables`.
 #' @param variables (named `list` of `strings`)\cr list of additional analysis variables, with
 #'   expected elements:
-#'   - `arm`: (`string`)\cr group variable, for which the covariate adjusted means of multiple
-#'   groups will be summarized. Specifically, the first level of `arm` variable is taken as the
-#'   reference group.
-#'   - `covariates`: (`character`)\cr a vector that can contain single variable names (such as
-#'   `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
+#'   - `arm` (`string`)\cr group variable, for which the covariate adjusted means of multiple
+#'     groups will be summarized. Specifically, the first level of `arm` variable is taken as the
+#'     reference group.
+#'   - `covariates` (`character`)\cr a vector that can contain single variable names (such as
+#'     `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
 #' @param interaction_item (`character`)\cr name of the variable that should have interactions
-#'   with arm. if the interaction is not needed, the default option is NULL
+#'   with arm. if the interaction is not needed, the default option is NULL.
+#'
 #' @examples
 #' h_ancova(
 #'   .var = "Sepal.Length",
@@ -79,20 +80,24 @@ h_ancova <- function(.var,
 
 #' @describeIn summarize_ancova Statistics function that produces a named list of results
 #'   of the investigated linear model.
+#'
 #' @inheritParams argument_convention
 #' @inheritParams h_ancova
 #' @param interaction_y (`character`)\cr a selected item inside of the interaction_item column
 #'   which will be used to select the specific ANCOVA results. if the interaction is not
 #'   needed, the default option is FALSE
-#'
 #' @return A named list of 5 statistics:
-#'   - `n`: count of complete sample size for the group.
-#'   - `lsmean`: estimated marginal means in the group.
-#'   - `lsmean_diff`: difference in estimated marginal means in comparison to the reference
-#'   group. If working with the reference group, this will be empty.
-#'   - `lsmean_diff_ci`: confidence level for difference in estimated marginal means in
-#'   comparison to the reference group.
-#'   - `pval`: p-value (not adjusted for multiple comparisons).
+#' \describe{
+#'   \item{n}{count of complete sample size for the group.}
+#'   \item{lsmean}{estimated marginal means in the group.}
+#'   \item{lsmean_diff}{difference in estimated marginal means in comparison to the reference group.
+#'     If working with the reference group, this will be empty.
+#'   }
+#'   \item{lsmean_diff_ci}{confidence level for difference in estimated marginal means in comparison to the
+#'     reference group.
+#'   }
+#'   \item{pval}{p-value (not adjusted for multiple comparisons).}
+#' }
 #'
 #' @examples
 #' library(dplyr)

--- a/R/summarize_glm_count.R
+++ b/R/summarize_glm_count.R
@@ -22,23 +22,23 @@ NULL
 NULL
 
 #' @describeIn h_glm_count Helper function to return results of a poisson model.
+#'
 #' @inheritParams argument_convention
-#' @param .df_row (`data frame`)\cr data set that includes all the variables that are called
+#' @param .df_row (`data.frame`)\cr data set that includes all the variables that are called
 #'   in `.var` and `variables`.
 #' @param variables (named `list` of `strings`)\cr list of additional analysis variables, with
 #'   expected elements:
-#'   - `arm`: (`string`)\cr group variable, for which the covariate adjusted means of multiple
-#'   groups will be summarized. Specifically, the first level of `arm` variable is taken as the
-#'   reference group.
-#'   - `covariates`: (`character`)\cr a vector that can contain single variable names (such as
-#'   `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
-#'   - `offset`: (`numeric`)\cr a numeric vector or scalar adding an offset.
+#'   - `arm` (`string`)\cr group variable, for which the covariate adjusted means of multiple
+#'     groups will be summarized. Specifically, the first level of `arm` variable is taken as the
+#'     reference group.
+#'   - `covariates` (`character`)\cr a vector that can contain single variable names (such as
+#'     `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
+#'   - `offset` (`numeric`)\cr a numeric vector or scalar adding an offset.
 #' @param `weights`(`character`)\cr a character vector specifying weights used
 #'  in averaging predictions. Number of weights must equal the number of levels included in the covariates.
 #'  Weights option passed to emmeans function (hyperlink) (link to emmeans documentation)
 #'
 #' @examples
-#'
 #' # Internal function - h_glm_poisson
 #' \dontrun{
 #' h_glm_poisson(
@@ -142,25 +142,24 @@ h_glm_quasipoisson <- function(.var,
 }
 
 #' @describeIn h_glm_count Helper function to return the results of the
-#' selected model (poisson, quasipoisson, negative binomial).
+#'   selected model (poisson, quasipoisson, negative binomial).
+#'
 #' @inheritParams argument_convention
-#' @param .df_row (`data frame`)\cr data set that includes all the variables that are called
+#' @param .df_row (`data.frame`)\cr data set that includes all the variables that are called
 #'   in `.var` and `variables`.
 #' @param variables (named `list` of `strings`)\cr list of additional analysis variables, with
 #'   expected elements:
-#'   - `arm`: (`string`)\cr group variable, for which the covariate adjusted means of multiple
-#'   groups will be summarized. Specifically, the first level of `arm` variable is taken as the
-#'   reference group.
-#'   - `covariates`: (`character`)\cr a vector that can contain single variable names (such as
-#'   `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
-#'   - `offset`: (`numeric`)\cr a numeric vector or scalar adding an offset.
+#'   - `arm` (`string`)\cr group variable, for which the covariate adjusted means of multiple
+#'     groups will be summarized. Specifically, the first level of `arm` variable is taken as the
+#'     reference group.
+#'   - `covariates` (`character`)\cr a vector that can contain single variable names (such as
+#'     `"X1"`), and/or interaction terms indicated by `"X1 * X2"`.
+#'   - `offset` (`numeric`)\cr a numeric vector or scalar adding an offset.
 #' @param `weights`(`character`)\cr character vector specifying weights used in averaging predictions.
 #' @param `distribution`(`character`)\cr a character value specifying the distribution
-#' used in the regression (poisson, quasipoisson).
-#'
+#'   used in the regression (poisson, quasipoisson).
 #'
 #' @examples
-#'
 #' # Internal function - h_glm_count
 #' \dontrun{
 #' h_glm_count(
@@ -189,18 +188,17 @@ h_glm_count <- function(.var,
 
 
 #' @describeIn h_glm_count Helper function to return the estimated means.
+#'
 #' @inheritParams argument_convention
-#' @param .df_row (`data frame`)\cr data set that includes all the variables that are called
+#' @param .df_row (`data.frame`)\cr data set that includes all the variables that are called
 #'   in `.var` and `variables`.
-# `list` of `strings`)\cr list of model fitting results.
-#' @param conf_level (`numeric`) value used to derive the confidence interval for the rate.
-#' @param obj (`glm.fit`) fitted model object used to derive the mean rate estimates in each treatment arm.
-#' @param `arm`: (`string`)\cr group variable, for which the covariate adjusted means of multiple
+#' @param conf_level (`numeric`)\cr value used to derive the confidence interval for the rate.
+#' @param obj (`glm.fit`)\cr fitted model object used to derive the mean rate estimates in each treatment arm.
+#' @param `arm` (`string`)\cr group variable, for which the covariate adjusted means of multiple
 #'   groups will be summarized. Specifically, the first level of `arm` variable is taken as the
 #'   reference group.
 #'
 #' @examples
-#'
 #' # Internal function - h_ppmeans
 #' \dontrun{
 #' fits <- h_glm_count(
@@ -257,20 +255,20 @@ h_ppmeans <- function(obj, .df_row, arm, conf_level) {
 
 #' @describeIn summarize_glm_count Statistics function that produces a named list of results
 #'   of the investigated poisson model.
+#'
 #' @inheritParams argument_convention
 #' @inheritParams h_glm_count
-#'
 #' @return A named list of 5 statistics:
-#'   - `n`: count of complete sample size for the group.
-#'   - `rate`: estimated event rate per follow-up time.
-#'   - `rate_ci`: confidence level for estimated rate per follow-up time.
-#'   - `rate_ratio`: Ratio of event rates in each treatment arm to the reference arm.
-#'   - `rate_ratio_ci`: confidence level for the rate ratio.
-#'   - `pval`: p-value.
-#'
+#' \describe{
+#'   \item{n}{count of complete sample size for the group.}
+#'   \item{rate}{estimated event rate per follow-up time.}
+#'   \item{rate_ci}{confidence level for estimated rate per follow-up time.}
+#'   \item{rate_ratio}{ratio of event rates in each treatment arm to the reference arm.}
+#'   \item{rate_ratio_ci}{confidence level for the rate ratio.}
+#'   \item{pval}{p-value.}
+#' }
 #'
 #' @examples
-#'
 #' # Internal function - s_change_from_baseline
 #' \dontrun{
 #' s_glm_count(

--- a/R/summarize_num_patients.R
+++ b/R/summarize_num_patients.R
@@ -5,25 +5,25 @@
 #' Count the number of unique and non-unique patients in a column (variable).
 #'
 #' @inheritParams argument_convention
-#' @param x (`character` or `factor`) \cr vector of patient IDs.
-#' @param count_by (`character` or `factor`) \cr optional vector to be combined with `x` when counting
+#' @param x (`character` or `factor`)\cr vector of patient IDs.
+#' @param count_by (`character` or `factor`)\cr optional vector to be combined with `x` when counting
 #' `nonunique` records.
-#' @param unique_count_suffix (`logical`) \cr should `"(n)"` suffix be added to `unique_count` labels.
+#' @param unique_count_suffix (`logical`)\cr should `"(n)"` suffix be added to `unique_count` labels.
 #' Defaults to `TRUE`.
 #'
 #' @name summarize_num_patients
 NULL
 
 #' @describeIn summarize_num_patients Statistics function which counts the number of
-#' unique patients, the corresponding percentage taken with respect to the
-#' total number of patients, and the number of non-unique patients.
+#'   unique patients, the corresponding percentage taken with respect to the
+#'   total number of patients, and the number of non-unique patients.
 #'
 #' @return A list with:
-#'   - `unique`: vector of count and percentage.
-#'   - `nonunique` : vector of count.
-#'   - `unique_count`: count.
-#'
-#' @export
+#' \describe{
+#'   \item{unique}{vector of count and percentage.}
+#'   \item{nonunique}{vector of count.}
+#'   \item{unique_count}{count.}
+#' }
 #'
 #' @examples
 #' # Use the statistics function to count number of unique and nonunique patients.
@@ -34,6 +34,8 @@ NULL
 #'   .N_col = 6L,
 #'   count_by = as.character(c(1, 1, 2, 1, 1, 1))
 #' )
+#'
+#' @export
 s_num_patients <- function(x, labelstr, .N_col, count_by = NULL, unique_count_suffix = TRUE) { # nolint
 
   checkmate::assert_string(labelstr)
@@ -60,12 +62,12 @@ s_num_patients <- function(x, labelstr, .N_col, count_by = NULL, unique_count_su
 }
 
 #' @describeIn summarize_num_patients Counts the number of unique patients in a column
-#' (variable), the corresponding percentage taken with respect to the total
-#' number of patients, and the number of non-unique patients in the column.
-#' Function serves as a wrapper that carries over both expected arguments `df`
-#' and `labelstr` in `cfun` of [summarize_row_groups()].
+#'   (variable), the corresponding percentage taken with respect to the total
+#'   number of patients, and the number of non-unique patients in the column.
+#'   Function serves as a wrapper that carries over both expected arguments `df`
+#'   and `labelstr` in `cfun` of [summarize_row_groups()].
 #'
-#' @param required (`character` or `NULL`) optional name of a variable that is required to be non-missing.
+#' @param required (`character` or `NULL`)\cr optional name of a variable that is required to be non-missing.
 #' @export
 #'
 #' @examples

--- a/R/summarize_patients_exposure_in_cols.R
+++ b/R/summarize_patients_exposure_in_cols.R
@@ -11,12 +11,16 @@ NULL
 
 #' @describeIn summarize_patients_exposure_in_cols Statistics function which counts numbers
 #'  of patients and the sum of exposure across all patients.
+#'
 #' @inheritParams argument_convention
 #' @param custom_label (`string` or `NULL`)\cr if provided and `labelstr` is empty then this will
-#' be used as label.
-#' @return [s_count_patients_sum_exposure()] returns a list with the statistics:\cr
-#' - `n_patients`: number of unique patients in `df`.
-#' - `sum_exposure`: sum of `.var` across all patients in `df`.
+#'   be used as label.
+#' @return [s_count_patients_sum_exposure()] returns a list with the statistics:
+#' \describe{
+#'   \item{n_patients}{number of unique patients in `df`.}
+#'   \item{sum_exposure}{sum of `.var` across all patients in `df`.}
+#' }
+#'
 #' @examples
 #' set.seed(1)
 #' df <- data.frame(
@@ -83,12 +87,13 @@ s_count_patients_sum_exposure <- function(df, # nolintr
 
 #' @describeIn summarize_patients_exposure_in_cols Layout creating function which adds the count
 #'   statistics of patients and the sum of analysis value in the column layout as content rows.
-#' @inheritParams argument_convention
-#' @param col_split (`flag`)\cr whether the columns should be split.
-#'  Set to `FALSE` when the required column split has been done already earlier in the layout pipe.
-#' @export
-#' @examples
 #'
+#' @inheritParams argument_convention
+#' @param col_split (`flag`)\cr whether the columns should be split. Set to `FALSE` when the required
+#'   column split has been done already earlier in the layout pipe.
+#' @export
+#'
+#' @examples
 #' lyt <- basic_table() %>%
 #'   split_cols_by("ARMCD", split_fun = add_overall_level("Total", first = FALSE)) %>%
 #'   summarize_patients_exposure_in_cols(var = "AVAL", col_split = TRUE) %>%

--- a/R/summarize_variables.R
+++ b/R/summarize_variables.R
@@ -6,11 +6,11 @@
 #' details for [s_summary].
 #'
 #' @inheritParams argument_convention
-#' @param quantiles (`numeric`) \cr of length two to specify the quantiles to calculate.
-#' @param quantile_type (`numeric`) \cr between 1 and 9 selecting quantile algorithms to be used. \cr
-#'   Default is set to `2` as this matches the default quantile algorithm in SAS `proc univariate` set by `QNTLDEF=5`.
+#' @param quantiles (`numeric`)\cr of length two to specify the quantiles to calculate.
+#' @param quantile_type (`numeric`)\cr between 1 and 9 selecting quantile algorithms to be used.
+#'   Default is set to 2 as this matches the default quantile algorithm in SAS `proc univariate` set by `QNTLDEF=5`.
 #'   This differs from R's default. See more about `type` in [stats::quantile()].
-#' @param test_mean (`numeric`) \cr to test against the mean under the null hypothesis when calculating p-value.
+#' @param test_mean (`numeric`)\cr to test against the mean under the null hypothesis when calculating p-value.
 #'
 #' @return A list of components with the same names as the arguments.
 #' @export
@@ -138,42 +138,42 @@ s_summary <- function(x,
 #'   Also, when the `mean` function is applied to an empty vector, `NA` will
 #'   be returned instead of `NaN`, the latter being standard behavior in R.
 #'
-#' @param control a (`list`) of parameters for descriptive statistics details, specified by using \cr
-#'    the helper function [control_summarize_vars()]. Some possible parameter options are: \cr
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for mean and median.
-#' * `quantiles`: numeric vector of length two to specify the quantiles.
-#' * `quantile_type` (`numeric`) \cr between 1 and 9 selecting quantile algorithms to be used. \cr
-#'   See more about `type` in [stats::quantile()].
-#' * `test_mean`: (`numeric`) \cr to test against the mean under the null hypothesis when calculating p-value.
+#' @param control (`list`)\cr parameters for descriptive statistics details, specified by using
+#'   the helper function [control_summarize_vars()]. Some possible parameter options are:
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for mean and median.
+#'   * `quantiles` (`numeric`)\cr vector of length two to specify the quantiles.
+#'   * `quantile_type` (`numeric`)\cr between 1 and 9 selecting quantile algorithms to be used.
+#'     See more about `type` in [stats::quantile()].
+#'   * `test_mean` (`numeric`)\cr value to test against the mean under the null hypothesis when calculating p-value.
 #'
-#' @return If `x` is of class `numeric`, returns a list with named items: \cr
-#' - `n`: the [length()] of `x`.
-#' - `sum`: the [sum()] of `x`.
-#' - `mean`: the [mean()] of `x`.
-#' - `sd`: the [stats::sd()] of `x`.
-#' - `se`: the standard error of `x` mean, i.e.: (`sd()/sqrt(length())]`).
-#' - `mean_sd`: the [mean()] and [stats::sd()] of `x`.
-#' - `mean_se`: the [mean()] of `x` and its standard error (see above).
-#' - `mean_ci`: the CI for the mean of `x` (from [stat_mean_ci()]).
-#' - `mean_sei`: the SE interval for the mean of `x`, i.e.: ([mean()] -/+ [stats::sd()]/[sqrt()]).
-#' - `mean_sdi`: the SD interval for the mean of `x`, i.e.: ([mean()] -/+ [stats::sd()]).
-#' - `mean_pval`: the two-sided p-value of the mean of `x` (from [stat_mean_pval()]).
-#' - `median`: the [stats::median()] of `x`.
-#' - `mad`:
-#' the median absolute deviation of `x`, i.e.: ([stats::median()] of `xc`, where `xc` = `x` - [stats::median()]).
-#' - `median_ci`: the CI for the median of `x` (from [stat_median_ci()]).
-#' - `quantiles`: two sample quantiles of `x` (from [stats::quantile()]).
-#' - `iqr`: the [stats::IQR()] of `x`.
-#' - `range`: the [range_noinf()] of `x`.
-#' - `min`: the [max()] of `x`.
-#' - `max`: the [min()] of `x`.
-#' - `cv`: the coefficient of variation of `x`, i.e.: (`sd()/mean() * 100`).
-#' - `geom_mean`: the geometric mean of `x`, i.e.: (`exp(mean(log(x)))`).
-#' - `geom_cv`: the geometric coefficient of variation of `x`, i.e.: (`sqrt(exp(sd(log(x))^2) - 1)*100`).
-#'
+#' @return If `x` is of class `numeric`, returns a list with the following named `numeric` items:
+#' \describe{
+#'   \item{n}{the [length()] of `x`.}
+#'   \item{sum}{the [sum()] of `x`.}
+#'   \item{mean}{the [mean()] of `x`.}
+#'   \item{sd}{the [stats::sd()] of `x`.}
+#'   \item{se}{the standard error of `x` mean, i.e.: (`sd(x) / sqrt(length(x))`).}
+#'   \item{mean_sd}{the [mean()] and [stats::sd()] of `x`.}
+#'   \item{mean_se}{the [mean()] of `x` and its standard error (see above).}
+#'   \item{mean_ci}{the CI for the mean of `x` (from [stat_mean_ci()]).}
+#'   \item{mean_sei}{the SE interval for the mean of `x`, i.e.: ([mean()] -/+ [stats::sd()] / [sqrt()]).}
+#'   \item{mean_sdi}{the SD interval for the mean of `x`, i.e.: ([mean()] -/+ [stats::sd()]).}
+#'   \item{mean_pval}{the two-sided p-value of the mean of `x` (from [stat_mean_pval()]).}
+#'   \item{median}{the [stats::median()] of `x`.}
+#'   \item{mad}{the median absolute deviation of `x`, i.e.: ([stats::median()] of `xc`,
+#'     where `xc` = `x` - [stats::median()]).
+#'   }
+#'   \item{median_ci}{the CI for the median of `x` (from [stat_median_ci()]).}
+#'   \item{quantiles}{two sample quantiles of `x` (from [stats::quantile()]).}
+#'   \item{iqr}{the [stats::IQR()] of `x`.}
+#'   \item{range}{the [range_noinf()] of `x`.}
+#'   \item{min}{the [max()] of `x`.}
+#'   \item{max}{the [min()] of `x`.}
+#'   \item{cv}{the coefficient of variation of `x`, i.e.: ([stats::sd()] / [mean()] * 100).}
+#'   \item{geom_mean}{the geometric mean of `x`, i.e.: (`exp(mean(log(x)))`).}
+#'   \item{geom_cv}{the geometric coefficient of variation of `x`, i.e.: (`sqrt(exp(sd(log(x)) ^ 2) - 1) * 100`).}
+#' }
 #' @method s_summary numeric
-#'
-#' @export
 #'
 #' @examples
 #' # `s_summary.numeric`
@@ -207,6 +207,8 @@ s_summary <- function(x,
 #' ## By comparison with `lapply`:
 #' X <- split(dta_test, f = with(dta_test, interaction(Group, sub_group)))
 #' lapply(X, function(x) s_summary(x$x))
+#'
+#' @export
 s_summary.numeric <- function(x, # nolint
                               na.rm = TRUE, # nolint
                               denom,
@@ -297,20 +299,21 @@ s_summary.numeric <- function(x, # nolint
 #'   per factor level. If there are no levels in `x`, the function fails. If `x` contains `NA`,
 #'   it is expected that `NA` have been conveyed to `na_level` appropriately beforehand with
 #'   [df_explicit_na()] or [explicit_na()].
-#' @param denom (`string`)\cr choice of denominator for factor proportions:\cr
-#'   can be `n` (number of values in this row and column intersection), `N_row` (total
-#'   number of values in this row across columns), or `N_col` (total number of values in
-#'   this column across rows).
-#' @return If `x` is of class `factor` or converted from `character`, returns a list with
-#'   named items:
-#'   - `n`: the [length()] of `x`.
-#'   - `count`: a list with the number of cases for each level of the
-#'      factor `x`
-#'   - `count_fraction`: similar to `count` but also includes the proportion of cases for each level of the
-#'      factor `x` relative to the denominator, or `NA` if the denominator is zero.
-#' @method s_summary factor
 #'
-#' @export
+#' @param denom (`string`)\cr choice of denominator for factor proportions. Options are:
+#'   - `n`: number of values in this row and column intersection.
+#'   - `N_row`: total number of values in this row across columns.
+#'   - `N_col`: total number of values in this column across rows.
+#'
+#' @return If `x` is of class `factor` or converted from `character`, returns a list with named `numeric` items:
+#' \describe{
+#'   \item{n}{the [length()] of `x`.}
+#'   \item{count}{a list with the number of cases for each level of the factor `x`.}
+#'   \item{count_fraction}{similar to `count` but also includes the proportion of cases for each level of the
+#'     factor `x` relative to the denominator, or `NA` if the denominator is zero.
+#'   }
+#' }
+#' @method s_summary factor
 #'
 #' @examples
 #' # `s_summary.factor`
@@ -330,6 +333,8 @@ s_summary.numeric <- function(x, # nolint
 #' x <- factor(c("a", "a", "b", "c", "a"))
 #' s_summary(x, denom = "N_row", .N_row = 10L)
 #' s_summary(x, denom = "N_col", .N_col = 20L)
+#'
+#' @export
 s_summary.factor <- function(x,
                              na.rm = TRUE, # nolint
                              denom = c("n", "N_row", "N_col"),
@@ -404,19 +409,21 @@ s_summary.character <- function(x,
 }
 
 #' @describeIn summarize_variables Method for logical class.
-#' @param denom (`string`)\cr choice of denominator for proportion:\cr
-#'   can be `n` (number of values in this row and column intersection), `N_row` (total
-#'   number of values in this row across columns), or `N_col` (total number of values in
-#'   this column across rows).
-#' @return If `x` is of class `logical`, returns a list with named items:
-#'   - `n`: the [length()] of `x` (possibly after removing `NA`s).
-#'   - `count`: count of `TRUE` in `x`.
-#'   - `count_fraction`: count and proportion of `TRUE` in `x` relative to the denominator,
-#'      or `NA` if the denominator is zero. Note that `NA`s in `x` are never counted or leading
-#'      to `NA` here.
-#' @method s_summary logical
 #'
-#' @export
+#' @param denom (`string`)\cr choice of denominator for proportion. Options are:
+#'   - `n`: number of values in this row and column intersection.
+#'   - `N_row`: total number of values in this row across columns.
+#'   - `N_col`: total number of values in this column across rows.
+#'
+#' @return If `x` is of class `logical`, returns a list with named `numeric` items:
+#' \describe{
+#'   \item{n}{the [length()] of `x` (possibly after removing `NA`s).}
+#'   \item{count}{count of `TRUE` in `x`.}
+#'   \item{count_fraction}{count and proportion of `TRUE` in `x` relative to the denominator, or `NA` if the
+#'     denominator is zero. Note that `NA`s in `x` are never counted or leading to `NA` here.
+#'   }
+#' }
+#' @method s_summary logical
 #'
 #' @examples
 #' # `s_summary.logical`
@@ -433,6 +440,8 @@ s_summary.character <- function(x,
 #' x <- c(TRUE, FALSE, TRUE, TRUE)
 #' s_summary(x, denom = "N_row", .N_row = 10L)
 #' s_summary(x, denom = "N_col", .N_col = 20L)
+#'
+#' @export
 s_summary.logical <- function(x,
                               na.rm = TRUE, # nolint
                               denom = c("n", "N_row", "N_col"),

--- a/R/survival_biomarkers_subgroups.R
+++ b/R/survival_biomarkers_subgroups.R
@@ -12,6 +12,7 @@
 #' @inheritParams fit_coxreg_multivar
 #' @inheritParams survival_duration_subgroups
 #' @name survival_biomarkers_subgroups
+#'
 #' @examples
 #' library(dplyr)
 #'
@@ -164,15 +165,14 @@ extract_survival_biomarkers <- function(variables,
 #'
 #' @param df (`data.frame`)\cr containing all analysis variables, as returned by
 #'   [extract_survival_biomarkers()].
-#' @param vars (`character`)\cr the name of statistics to be reported among
-#'  `n_tot_events` (total number of events per group),
-#'  `n_tot` (total number of observations per group),
-#'  `median` (median survival time),
-#'  `hr` (hazard ratio),
-#'  `ci` (confidence interval of hazard ratio) and
-#'  `pval` (p value of the effect).
-#'  Note, one of the statistics `n_tot` and `n_tot_events`, as well as both `hr` and `ci`
-#'  are required.
+#' @param vars (`character`)\cr the names of statistics to be reported among:
+#'   - `n_tot_events`: total number of events per group.
+#'   - `n_tot`: total number of observations per group.
+#'   - `median`: median survival time.
+#'   - `hr`: hazard ratio.
+#'   - `ci`: confidence interval of hazard ratio.
+#'   - `pval`: p-value of the effect.
+#'   Note, one of the statistics `n_tot` and `n_tot_events`, as well as both `hr` and `ci` are required.
 #' @seealso [h_tab_surv_one_biomarker()] which is used internally, [extract_survival_biomarkers()].
 #' @note In contrast to [tabulate_survival_subgroups()] this tabulation function does
 #'   not start from an input layout `lyt`. This is because internally the table is

--- a/R/survival_coxph_pairwise.R
+++ b/R/survival_coxph_pairwise.R
@@ -6,29 +6,29 @@
 #'
 #' @inheritParams argument_convention
 #' @inheritParams s_surv_time
-#' @param strat (`character` or `NULL`) variable names indicating stratification factors.
-#' @param control (`list`) \cr parameters for comparison details, specified by using \cr
-#'    the helper function [control_coxph()]. Some possible parameter options are: \cr
-#' * `pval_method`: (`string`) \cr p-value method for testing hazard ratio = 1.
-#'   Default method is "log-rank" which comes from [survival::survdiff()], can also be set to "wald" or "likelihood"
-#'   that comes from [survival::coxph()].
-#' * `ties`: (`string`) \cr specifying the method for tie handling. Default is "efron",
-#'   can also be set to "breslow" or "exact". See more in [survival::coxph()]
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for HR.
+#' @param strat (`character` or `NULL`)\cr variable names indicating stratification factors.
+#' @param control (`list`)\cr parameters for comparison details, specified by using the helper function
+#'   [control_coxph()]. Some possible parameter options are:
+#'   * `pval_method` (`string`)\cr p-value method for testing hazard ratio = 1. Default method is "log-rank" which
+#'     comes from [survival::survdiff()], can also be set to "wald" or "likelihood" (from [survival::coxph()]).
+#'   * `ties` (`string`)\cr specifying the method for tie handling. Default is "efron",
+#'     can also be set to "breslow" or "exact". See more in [survival::coxph()]
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for HR.
 #'
 #' @importFrom stats pchisq
-#'
 #' @name survival_coxph_pairwise
 NULL
 
 #' @describeIn survival_coxph_pairwise Statistics Function which analyzes HR, CIs of HR and p-value with coxph model.
 #'
 #' @return The statistics are:
-#' * `pvalue` : p-value to test HR = 1.
-#' * `hr` : hazard ratio.
-#' * `hr_ci` : confidence interval for hazard ratio.
-#' * `n_tot` : total number of observations
-#' * `n_tot_events` : total number of events
+#' \describe{
+#'   \item{pvalue}{p-value to test HR = 1.}
+#'   \item{hr}{hazard ratio.}
+#'   \item{hr_ci}{confidence interval for hazard ratio.}
+#'   \item{n_tot}{total number of observations.}
+#'   \item{n_tot_events}{total number of events.}
+#' }
 #'
 #' @examples
 #' library(dplyr)

--- a/R/survival_duration_subgroups.R
+++ b/R/survival_duration_subgroups.R
@@ -9,7 +9,7 @@
 #'
 #' @inheritParams argument_convention
 #' @inheritParams survival_coxph_pairwise
-#' @param data (`data frame`)\cr the dataset containing the variables to summarize.
+#' @param data (`data.frame`)\cr the dataset containing the variables to summarize.
 #' @param groups_lists (named `list` of `list`)\cr optionally contains for each `subgroups` variable a
 #'   list, which specifies the new group levels via the names and the
 #'   levels that belong to it in the character vectors that are elements of the list.

--- a/R/survival_time.R
+++ b/R/survival_time.R
@@ -2,16 +2,16 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' Summarize median survival time and CIs, percentiles of survival times, \cr
-#' survival time range of censored/event patients.
+#' Summarize median survival time and CIs, percentiles of survival times, survival
+#' time range of censored/event patients.
 #'
 #' @inheritParams argument_convention
-#' @param control a (`list`) of parameters for comparison details, specified by using \cr
-#'    the helper function [control_surv_time]. Some possible parameter options are: \cr
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for survival time.
-#' * `conf_type`: (`string`) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-#'    see more in [survival::survfit()]. Note option, "none" is not supported.
-#' * `quantiles`: numeric vector of length two to specify the quantiles of survival time.
+#' @param control (`list`)\cr parameters for comparison details, specified by using the helper function
+#'   [control_surv_time()]. Some possible parameter options are:
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for survival time.
+#'   * `conf_type` (`string`)\cr confidence interval type. Options are "plain" (default), "log", or "log-log",
+#'     see more in [survival::survfit()]. Note option "none" is not supported.
+#'   * `quantiles` (`numeric`)\cr vector of length two to specify the quantiles of survival time.
 #'
 #' @name survival_time
 NULL
@@ -20,12 +20,14 @@ NULL
 #'  `range_censor` and `range_event`.
 #'
 #' @return The statistics are:
-#' * `median` : median survival time.
-#' * `median_ci` : confidence interval for median time.
-#' * `quantiles` : survival time for two specified quantiles.
-#' * `range_censor` : survival time range for censored observations.
-#' * `range_event` : survival time range for observations with events.
-#' * `range` : survival time range for all observations.
+#' \describe{
+#'   \item{median}{median survival time.}
+#'   \item{median_ci}{confidence interval for median time.}
+#'   \item{quantiles}{survival time for two specified quantiles.}
+#'   \item{range_censor}{survival time range for censored observations.}
+#'   \item{range_event}{survival time range for observations with events.}
+#'   \item{range}{survival time range for all observations.}
+#' }
 #'
 #' @examples
 #' library(dplyr)
@@ -115,8 +117,9 @@ a_surv_time <- make_afun(
 
 #' @describeIn survival_time Analyze Function which adds the survival times analysis
 #'   to the input layout. Note that additional formatting arguments can be used here.
-#' @inheritParams argument_convention
+#'
 #' @export
+#'
 #' @examples
 #' basic_table() %>%
 #'   split_cols_by(var = "ARMCD") %>%

--- a/R/survival_timepoint.R
+++ b/R/survival_timepoint.R
@@ -2,29 +2,30 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' Summarize patient's survival rate and difference of survival rates between groups at a time point.
+#' Summarize patients' survival rate and difference of survival rates between groups at a time point.
 #'
 #' @inheritParams argument_convention
 #' @inheritParams s_surv_time
-#' @param time_point (`number`) \cr survival time point of interest.
-#' @param control a (`list`) of parameters for comparison details, specified by using \cr
-#'    the helper function [`control_surv_timepoint`]. Some possible parameter options are: \cr
-#' * `conf_level`: (`proportion`)\cr confidence level of the interval for survival rate.
-#' * `conf_type`: (`string`) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-#'    see more in [survival::survfit()]. Note that the option "none" is no longer supported.
-#' * `time_point`: (`number`) \cr survival time point of interest.
+#' @param time_point (`number`)\cr survival time point of interest.
+#' @param control (`list`)\cr parameters for comparison details, specified by using the helper function
+#'   [control_surv_timepoint()]. Some possible parameter options are:
+#'   * `conf_level` (`proportion`)\cr confidence level of the interval for survival rate.
+#'   * `conf_type` (`string`)\cr confidence interval type. Options are "plain" (default), "log", "log-log",
+#'     see more in [survival::survfit()]. Note option "none" is no longer supported.
+#'   * `time_point` (`number`)\cr survival time point of interest.
 #'
 #' @name survival_timepoint
-#'
 NULL
 
 #' @describeIn survival_timepoint Statistics Function which analyzes survival rate.
 #'
 #' @return The statistics are:
-#' * `pt_at_risk` : patients remaining at risk.
-#' * `event_free_rate` : event free rate (%).
-#' * `rate_se` : standard error of event free rate.
-#' * `rate_ci` : confidence interval for event free rate.
+#' \describe{
+#'   \item{pt_at_risk}{patients remaining at risk.}
+#'   \item{event_free_rate}{event free rate (%).}
+#'   \item{rate_se}{standard error of event free rate.}
+#'   \item{rate_ci}{confidence interval for event free rate.}
+#' }
 #'
 #' @examples
 #' library(dplyr)
@@ -111,10 +112,13 @@ a_surv_timepoint <- make_afun(
 )
 
 #' @describeIn survival_timepoint Statistics Function which analyzes difference between two survival rates.
+#'
 #' @return The statistics are:
-#' * `rate_diff` : event free rate difference between two groups.
-#' * `rate_diff_ci` : confidence interval for the difference.
-#' * `ztest_pval` : p-value to test the difference is 0.
+#' \describe{
+#'   \item{rate_diff}{event free rate difference between two groups.}
+#'   \item{rate_diff_ci}{confidence interval for the difference.}
+#'   \item{ztest_pval}{p-value to test the difference is 0.}
+#' }
 #'
 #' @examples
 #' df_ref_group <- adtte_f %>%
@@ -208,6 +212,7 @@ a_surv_timepoint_diff <- make_afun(
 
 #' @describeIn survival_timepoint Analyze Function which adds the survival rate analysis to the input layout.
 #'   Note that additional formatting arguments can be used here.
+#'
 #' @inheritParams argument_convention
 #' @param method (`string`)\cr either `surv` (survival estimations),
 #'   `surv_diff` (difference in survival with the control) or `both`.

--- a/R/utils.R
+++ b/R/utils.R
@@ -338,11 +338,11 @@ study_arm <- function(x) {
 #'
 #' This produces \code{loess} smoothed estimates of `y` with Student confidence intervals.
 #'
-#' @param df (`data.frame`)\cr.
+#' @param df (`data.frame`)\cr data set containing all analysis variables.
 #' @param x (`character`)\cr value with x column name.
 #' @param y (`character`)\cr value with y column name.
 #' @param groups (`character`)\cr vector with optional grouping variables names.
-#' @param level (`numeric`) level of confidence interval to use (0.95 by default).
+#' @param level (`numeric`)\cr level of confidence interval to use (0.95 by default).
 #' @return A `data.frame` with original `x`, smoothed `y`, `ylow`, `yhigh` and
 #' optional `groups` variables formatted to factor type.
 #' @export
@@ -409,7 +409,7 @@ get_smooths <- function(df, x, y, groups = NULL, level = 0.95) {
 #'
 #' Small utility function for better readability.
 #'
-#' @param x (`vector`)\cr where to count the non-missing values.
+#' @param x (`any`)\cr vector in which to count non-missing values.
 #'
 #' @return Number of non-missing values.
 #'
@@ -429,7 +429,7 @@ n_available <- function(x) {
 #' @description This is a helper function that is used in tests.
 #'
 #' @param x (`vector`)\cr vector of elements that needs new labels.
-#' @param varlabels (`vector`)\cr labels for `x`.
+#' @param varlabels (`character`)\cr vector of labels for `x`.
 #' @param ... further parameters to be added to the list.
 #'
 #' @export

--- a/R/utils_checkmate.R
+++ b/R/utils_checkmate.R
@@ -4,7 +4,7 @@
 #' Additional assertion functions which can be used together with the `checkmate` package.
 #'
 #' @param x (`any`)\cr object to test.
-#' @param df (`data frame`)\cr data set to test.
+#' @param df (`data.frame`)\cr data set to test.
 #' @param variables (named `list` of `character`)\cr list of variables to test.
 #' @param include_boundaries (`logical`)\cr whether to include boundaries when testing
 #'   for proportions.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -46,6 +46,7 @@ reference:
       - starts_with("count_", internal = TRUE)
       - starts_with("estimate_", internal = TRUE)
       - starts_with("summarize_", internal = TRUE)
+      - starts_with("surv_", internal = TRUE)
       - starts_with("tabulate_", internal = TRUE)
       - test_proportion_diff
       - -estimate_coef

--- a/man/abnormal.Rd
+++ b/man/abnormal.Rd
@@ -35,7 +35,7 @@ count_abnormal(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
@@ -75,13 +75,13 @@ vector with \code{num} and \code{denom} counts of patients.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Primary analysis variable \code{.var} indicates the abnormal range result (character or factor)
-and additional analysis variables are \code{id} (character or factor) and \code{baseline} (character or
-factor). For each direction specified in \code{abnormal} (e.g. high or low) count patients in the
+Primary analysis variable \code{.var} indicates the abnormal range result (\code{character} or \code{factor})
+and additional analysis variables are \code{id} (\code{character} or \code{factor}) and \code{baseline} (\code{character} or
+\code{factor}). For each direction specified in \code{abnormal} (e.g. high or low) count patients in the
 numerator and denominator as follows:
 \describe{
-\item{\code{num}}{the number of patients with this abnormality recorded while on treatment.}
-\item{\code{denom}}{the number of patients with at least one post-baseline assessment.}
+\item{num}{the number of patients with this abnormality recorded while on treatment.}
+\item{denom}{the number of patients with at least one post-baseline assessment.}
 }
 Note, the denominator includes patients that might have other abnormal levels at baseline,
 and patients with missing baseline. Note, optionally patients with this abnormality at

--- a/man/abnormal_by_baseline.Rd
+++ b/man/abnormal_by_baseline.Rd
@@ -36,14 +36,14 @@ count_abnormal_by_baseline(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
 \item{abnormal}{(\code{character})\cr identifying the abnormal range level(s) in \code{.var}.}
 
-\item{na_level}{(\code{string}) \cr the explicit \code{na_level} argument you used in the pre-processing steps (maybe with
+\item{na_level}{(\code{string})\cr the explicit \code{na_level} argument you used in the pre-processing steps (maybe with
 \code{df_explicit_na()}). The default is \code{"<Missing>"}.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
@@ -77,7 +77,7 @@ analysis variables are \code{id} (character or factor) and \code{baseline} (char
 direction specified in \code{abnormal} (e.g. high or low) we condition on baseline range result and count
 patients in the numerator and denominator as follows:
 \itemize{
-\item \verb{Not <abnormal>}
+\item \verb{Not <Abnormal>}
 \itemize{
 \item \code{denom}: the number of patients without abnormality at baseline (excluding those with missing baseline)
 \item \code{num}:  the number of patients in \code{denom} who also have at least one abnormality post-baseline
@@ -130,7 +130,6 @@ s_count_abnormal_by_baseline(df, .var = "ANRIND", abnormal = "HIGH")
 afun <- make_afun(a_count_abnormal_by_baseline, .ungroup_stats = "fraction")
 afun(df, .var = "ANRIND", abnormal = "LOW")
 }
-
 
 # Layout creating function.
 basic_table() \%>\%

--- a/man/abnormal_by_marked.Rd
+++ b/man/abnormal_by_marked.Rd
@@ -5,7 +5,7 @@
 \alias{s_count_abnormal_by_marked}
 \alias{a_count_abnormal_by_marked}
 \alias{count_abnormal_by_marked}
-\title{Count patients with marked laboratory abnormalities}
+\title{Count Patients with Marked Laboratory Abnormalities}
 \usage{
 s_count_abnormal_by_marked(
   df,
@@ -34,12 +34,12 @@ count_abnormal_by_marked(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.spl_context}{(\verb{data frame})\cr gives information about ancestor split states
+\item{.spl_context}{(\code{data.frame})\cr gives information about ancestor split states
 that is passed by \code{rtables}.}
 
 \item{category}{(\code{list})\cr with different marked category names for single
@@ -73,7 +73,6 @@ or last marked laboratory abnormality was observed (factor).
 Additional analysis variables are \code{id} (character or factor) and \code{direction} indicating
 the direction of the abnormality (factor).
 Denominator is number of patients with at least one valid measurement during
-treatment (post-baseline), and patients in the numerator are considered as follows:
 \itemize{
 \item For \verb{Single, not last} and \verb{Last or replicated}: Numerator is number of patients
 with \verb{Single, not last} and \verb{Last or replicated} levels, respectively.

--- a/man/abnormal_by_worst_grade.Rd
+++ b/man/abnormal_by_worst_grade.Rd
@@ -32,12 +32,12 @@ count_abnormal_by_worst_grade(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.spl_context}{(\verb{data frame})\cr gives information about ancestor split states
+\item{.spl_context}{(\code{data.frame})\cr gives information about ancestor split states
 that is passed by \code{rtables}.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}

--- a/man/abnormal_by_worst_grade_worsen.Rd
+++ b/man/abnormal_by_worst_grade_worsen.Rd
@@ -31,16 +31,16 @@ count_abnormal_lab_worsen_by_baseline(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{variables}{(named \code{list} of \code{string}) \cr list of additional analysis variables including:
+\item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables including:
 \itemize{
-\item \code{id} (\code{string}): \cr subject variable name
-\item \code{baseline_var} (\code{string}): \cr name of the data column containing baseline toxicity variable
-\item \code{direction_var} (\code{string}): See \code{direction_var} for more detail
+\item \code{id} (\code{string})\cr subject variable name.
+\item \code{baseline_var} (\code{string})\cr name of the data column containing baseline toxicity variable.
+\item \code{direction_var} (\code{string})\cr see \code{direction_var} for more details.
 }}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -63,8 +63,8 @@ to avoid warnings from \code{rtables}.}
 counts and fraction of patients whose worst post-baseline lab grades are worse than
 their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
 
-\code{\link[=a_count_abnormal_lab_worsen_by_baseline]{a_count_abnormal_lab_worsen_by_baseline()}} returns
-the corresponding list with formatted \code{\link[rtables:CellValue]{rtables::CellValue()}}.
+\code{\link[=a_count_abnormal_lab_worsen_by_baseline]{a_count_abnormal_lab_worsen_by_baseline()}} returns the corresponding list with
+formatted \code{\link[rtables:CellValue]{rtables::CellValue()}}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
@@ -77,12 +77,10 @@ Patient count and fraction for laboratory events (worsen from baseline) shift ta
 counts and fraction of patients whose worst post-baseline lab grades are worse than
 their baseline grades, for post-baseline worst grades "1", "2", "3", "4" and "Any".
 
-\item \code{a_count_abnormal_lab_worsen_by_baseline()}: Formatted Analysis function which can be further customized by
-calling \code{\link[rtables:make_afun]{rtables::make_afun()}} on it. It is used as \code{afun} in \code{\link[rtables:analyze]{rtables::analyze()}}.
+\item \code{a_count_abnormal_lab_worsen_by_baseline()}: 
 
-\item \code{count_abnormal_lab_worsen_by_baseline()}: Layout
-creating function which can be used for creating tables, which can take statistics
-function arguments and additional format arguments (see below).
+\item \code{count_abnormal_lab_worsen_by_baseline()}: Layout creating function which can be used for creating tables,
+which can take statistics function arguments and additional format arguments (see below).
 
 }}
 \examples{

--- a/man/analyze_vars_in_cols.Rd
+++ b/man/analyze_vars_in_cols.Rd
@@ -113,5 +113,5 @@ result <- build_table(lyt, df = adpp)
 result
 }
 \seealso{
-\link{summarize_vars}, \link[rtables:analyze_colvars]{rtables::analyze_colvars}.
+\link{summarize_vars}, \code{\link[rtables:analyze_colvars]{rtables::analyze_colvars()}}.
 }

--- a/man/append_varlabels.Rd
+++ b/man/append_varlabels.Rd
@@ -9,7 +9,7 @@ append_varlabels(lyt, df, vars, indent = 0L)
 \arguments{
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{vars}{(\code{character})\cr variable names of which the labels are to be looked up in \code{df}.}
 

--- a/man/argument_convention.Rd
+++ b/man/argument_convention.Rd
@@ -6,7 +6,7 @@
 \arguments{
 \item{...}{additional arguments for the lower level functions.}
 
-\item{.df_row}{(\verb{data frame})\cr data frame across all of the columns for the given row split.}
+\item{.df_row}{(\code{data.frame})\cr data frame across all of the columns for the given row split.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -15,7 +15,7 @@
 
 \item{.N_row}{(\code{count})\cr column-wise N (column count) for the full column that is passed by \code{rtables}.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.stats}{(\code{character})\cr statistics to select for the table.}
 
@@ -28,7 +28,7 @@
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.spl_context}{(\verb{data frame})\cr gives information about ancestor split states
+\item{.spl_context}{(\code{data.frame})\cr gives information about ancestor split states
 that is passed by \code{rtables}.}
 
 \item{col_by}{(\code{factor})\cr defining column groups.}
@@ -37,18 +37,18 @@ that is passed by \code{rtables}.}
 
 \item{data}{(\code{data.frame})\cr the dataset containing the variables to summarize.}
 
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{draw}{(\code{flag})\cr whether the plot should be drawn.}
 
 \item{drop}{(\code{flag})\cr should non appearing occurrence levels be dropped from the resulting table.
 Note that in that case the remaining occurrence levels in the table are sorted alphabetically.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{indent_mod}{(\code{count}) \cr it can be negative. Modifier for the default indent position for the
+\item{indent_mod}{(\code{count})\cr it can be negative. Modifier for the default indent position for the
 structure created by this function(subtable, content table, or row) and
 all of that structure's children. Defaults to 0, which corresponds to the
 unmodified default behavior.}

--- a/man/assertions.Rd
+++ b/man/assertions.Rd
@@ -54,7 +54,7 @@ the heuristic implemented in \code{\link[checkmate]{vname}}.}
 \item{add}{[\code{AssertCollection}]\cr
 Collection to store assertion messages. See \code{\link[checkmate]{AssertCollection}}.}
 
-\item{df}{(\verb{data frame})\cr data set to test.}
+\item{df}{(\code{data.frame})\cr data set to test.}
 
 \item{variables}{(named \code{list} of \code{character})\cr list of variables to test.}
 

--- a/man/c_label_n.Rd
+++ b/man/c_label_n.Rd
@@ -7,7 +7,7 @@
 c_label_n(df, labelstr, .N_row)
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{labelstr}{(\code{character})\cr label of the level of the parent split currently being summarized
 (must be present as second argument in Content Row Functions).}

--- a/man/check_diff_prop_ci.Rd
+++ b/man/check_diff_prop_ci.Rd
@@ -9,18 +9,15 @@ check_diff_prop_ci(rsp, grp, strata = NULL, conf_level, correct = NULL)
 \arguments{
 \item{rsp}{(\code{logical})\cr whether each subject is a responder or not.}
 
-\item{grp}{(\code{factor})\cr
-vector assigning observations to one out of two groups
+\item{grp}{(\code{factor})\cr vector assigning observations to one out of two groups
 (e.g. reference and treatment group).}
 
-\item{strata}{(\code{factor})\cr
-with one level per stratum and same length as \code{rsp}.}
+\item{strata}{(\code{factor})\cr variable with one level per stratum and same length as \code{rsp}.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{correct}{\code{logical}\cr
-include the continuity correction. For further information, see for example
-\code{\link[stats:prop.test]{stats::prop.test()}}.}
+\item{correct}{\code{logical}\cr include the continuity correction. For further
+information, see \code{\link[stats:prop.test]{stats::prop.test()}}.}
 }
 \description{
 Verifies that and/or convert arguments into valid values to be used in the

--- a/man/compare_variables.Rd
+++ b/man/compare_variables.Rd
@@ -88,7 +88,7 @@ compare_vars(
 \arguments{
 \item{x}{(\code{numeric})\cr vector of numbers we want to analyze.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -138,8 +138,7 @@ If \code{x} is of class \code{numeric}, returns a list with named items:
 \item \code{pval}: the p-value.
 }
 
-If \code{x} is of class \code{factor} or converted from \code{character}, returns a list with
-named items:
+If \code{x} is of class \code{factor} or converted from \code{character}, returns a list with named items:
 \itemize{
 \item all items from \code{\link[=s_summary.factor]{s_summary.factor()}}.
 \item \code{pval}: the p-value.

--- a/man/control_coxph.Rd
+++ b/man/control_coxph.Rd
@@ -11,10 +11,10 @@ control_coxph(
 )
 }
 \arguments{
-\item{pval_method}{(\code{string}) \cr p-value method for testing hazard ratio = 1.
+\item{pval_method}{(\code{string})\cr p-value method for testing hazard ratio = 1.
 Default method is \code{"log-rank"}, can also be set to \code{"wald"} or \code{"likelihood"}.}
 
-\item{ties}{(\code{string}) \cr specifying the method for tie handling. Default is \code{"efron"},
+\item{ties}{(\code{string})\cr specifying the method for tie handling. Default is \code{"efron"},
 can also be set to \code{"breslow"} or \code{"exact"}. see more in \code{\link[survival:coxph]{survival::coxph()}}}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}

--- a/man/control_incidence_rate.Rd
+++ b/man/control_incidence_rate.Rd
@@ -14,13 +14,13 @@ control_incidence_rate(
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{conf_type}{(\code{string}) \cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
+\item{conf_type}{(\code{string})\cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
 for confidence interval type.}
 
-\item{time_unit_input}{(\code{string}) \cr \code{day}, \code{month}, or \code{year} (default)
+\item{time_unit_input}{(\code{string})\cr \code{day}, \code{month}, or \code{year} (default)
 indicating time unit for data input.}
 
-\item{time_unit_output}{(\code{numeric}) \cr time unit for desired output (in person-years).}
+\item{time_unit_output}{(\code{numeric})\cr time unit for desired output (in person-years).}
 }
 \value{
 A list of components with the same name as the arguments.

--- a/man/control_lineplot_vars.Rd
+++ b/man/control_lineplot_vars.Rd
@@ -13,15 +13,15 @@ control_lineplot_vars(
 )
 }
 \arguments{
-\item{x}{(\code{character} scalar) x variable name. \cr}
+\item{x}{(\code{character})\cr x variable name.}
 
-\item{y}{(\code{character} scalar) y variable name. \cr}
+\item{y}{(\code{character})\cr y variable name.}
 
-\item{strata}{(\code{character} scalar or \code{NA}) strata variable name. \cr}
+\item{strata}{(\code{character} or \code{NA})\cr strata variable name.}
 
-\item{paramcd}{(\code{character} scalar or \code{NA}) paramcd variable name. \cr}
+\item{paramcd}{(\code{character} or \code{NA})\cr paramcd variable name.}
 
-\item{y_unit}{(\code{character} scalar or \code{NA}) y_unit variable name. \cr}
+\item{y_unit}{(\code{character} or \code{NA})\cr y_unit variable name.}
 }
 \value{
 A named character vector with names of variables.

--- a/man/control_summarize_vars.Rd
+++ b/man/control_summarize_vars.Rd
@@ -14,13 +14,13 @@ control_summarize_vars(
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{quantiles}{(\code{numeric}) \cr of length two to specify the quantiles to calculate.}
+\item{quantiles}{(\code{numeric})\cr of length two to specify the quantiles to calculate.}
 
-\item{quantile_type}{(\code{numeric}) \cr between 1 and 9 selecting quantile algorithms to be used. \cr
-Default is set to \code{2} as this matches the default quantile algorithm in SAS \verb{proc univariate} set by \code{QNTLDEF=5}.
+\item{quantile_type}{(\code{numeric})\cr between 1 and 9 selecting quantile algorithms to be used.
+Default is set to 2 as this matches the default quantile algorithm in SAS \verb{proc univariate} set by \code{QNTLDEF=5}.
 This differs from R's default. See more about \code{type} in \code{\link[stats:quantile]{stats::quantile()}}.}
 
-\item{test_mean}{(\code{numeric}) \cr to test against the mean under the null hypothesis when calculating p-value.}
+\item{test_mean}{(\code{numeric})\cr to test against the mean under the null hypothesis when calculating p-value.}
 }
 \value{
 A list of components with the same names as the arguments.

--- a/man/control_surv_time.Rd
+++ b/man/control_surv_time.Rd
@@ -13,10 +13,10 @@ control_surv_time(
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{conf_type}{(\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-see more in \code{\link[survival:survfit]{survival::survfit()}}. Note that the option "none" is no longer supported.}
+\item{conf_type}{(\code{string})\cr confidence interval type. Options are "plain" (default), "log", "log-log",
+see more in \code{\link[survival:survfit]{survival::survfit()}}. Note option "none" is no longer supported.}
 
-\item{quantiles}{(\code{numeric}) \cr of length two to specify the quantiles of survival time.}
+\item{quantiles}{(\code{numeric})\cr of length two to specify the quantiles of survival time.}
 }
 \value{
 A list of components with the same names as the arguments

--- a/man/control_surv_timepoint.Rd
+++ b/man/control_surv_timepoint.Rd
@@ -12,8 +12,8 @@ control_surv_timepoint(
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{conf_type}{(\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-see more in \code{\link[survival:survfit]{survival::survfit()}}. Note that the option "none" is no longer supported.}
+\item{conf_type}{(\code{string})\cr confidence interval type. Options are "plain" (default), "log", "log-log",
+see more in \code{\link[survival:survfit]{survival::survfit()}}. Note option "none" is no longer supported.}
 }
 \value{
 A list of components with the same names as the arguments

--- a/man/count_cumulative.Rd
+++ b/man/count_cumulative.Rd
@@ -71,11 +71,8 @@ to avoid warnings from \code{rtables}.}
 \item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
-A named list:
-\itemize{
-\item \code{count_fraction}: a list with each \code{thresholds} value as a component, each component
+A named list of \code{count_fraction}s: a list with each \code{thresholds} value as a component, each component
 contains a vector for the count and fraction.
-}
 
 \code{\link[=a_count_cumulative]{a_count_cumulative()}} returns the corresponding list with formatted \code{\link[rtables:CellValue]{rtables::CellValue()}}.
 }
@@ -87,8 +84,7 @@ greater than, or greater or equal to user-specific thresholds.
 }
 \section{Functions}{
 \itemize{
-\item \code{s_count_cumulative()}: Statistics function that produces a named lists given a
-(\code{numeric}) vector of thresholds.
+\item \code{s_count_cumulative()}: Statistics function that produces a named lists given a numeric vector of thresholds.
 
 \item \code{a_count_cumulative()}: Formatted Analysis function which can be further customized by calling
 \code{\link[rtables:make_afun]{rtables::make_afun()}} on it. It is used as \code{afun} in \code{\link[rtables:analyze]{rtables::analyze()}}.
@@ -125,7 +121,6 @@ basic_table() \%>\%
     thresholds = c(40, 60)
   ) \%>\%
   build_table(tern_ex_adsl)
-
 }
 \seealso{
 Relevant helper function \code{\link[=h_count_cumulative]{h_count_cumulative()}}, and descriptive function \code{\link[=d_count_cumulative]{d_count_cumulative()}}

--- a/man/count_occurrences.Rd
+++ b/man/count_occurrences.Rd
@@ -40,16 +40,18 @@ count_occurrences(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{denom}{(\code{string})\cr choice of denominator for patient proportions:\cr
-can be \code{N_col} (total number of patients in this column across rows) or
-\code{n} (number of patients with any occurrences).}
+\item{denom}{(\code{string})\cr choice of denominator for patient proportions. Can be:
+\itemize{
+\item \code{N_col}: total number of patients in this column across rows
+\item \code{n}: number of patients with any occurrences
+}}
 
 \item{.N_col}{(\code{count})\cr row-wise N (row group count) for the group of observations being analyzed
 (i.e. with no column-based subsetting) that is passed by \code{rtables}.}
 
-\item{.df_row}{(\verb{data frame})\cr data frame across all of the columns for the given row split.}
+\item{.df_row}{(\code{data.frame})\cr data frame across all of the columns for the given row split.}
 
 \item{drop}{(\code{flag})\cr should non appearing occurrence levels be dropped from the resulting table.
 Note that in that case the remaining occurrence levels in the table are sorted alphabetically.}
@@ -57,7 +59,7 @@ Note that in that case the remaining occurrence levels in the table are sorted a
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 
@@ -82,10 +84,10 @@ to avoid warnings from \code{rtables}.}
 }
 \value{
 A list with:
-\itemize{
-\item \code{count}: list of counts with one element per occurrence
-\item \code{count_fraction}: list of counts and fractions with one element per occurrence.
-\item \code{fraction}: list of numerators and denominators with one element per occurrence.
+\describe{
+\item{count}{list of counts with one element per occurrence.}
+\item{count_fraction}{list of counts and fractions with one element per occurrence.}
+\item{fraction}{list of numerators and denominators with one element per occurrence.}
 }
 }
 \description{
@@ -127,6 +129,7 @@ s_count_occurrences(
   .var = "MHDECOD",
   id = "USUBJID"
 )
+
 #  We need to ungroup `count_fraction` first so that the `rtables` formatting
 # function `format_count_fraction()` can be applied correctly.
 afun <- make_afun(a_count_occurrences, .ungroup_stats = c("count", "count_fraction", "fraction"))

--- a/man/count_occurrences_by_grade.Rd
+++ b/man/count_occurrences_by_grade.Rd
@@ -51,7 +51,7 @@ summarize_occurrences_by_grade(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
@@ -59,7 +59,7 @@ by a statistics function.}
 \item{.N_col}{(\code{count})\cr row-wise N (row group count) for the group of observations being analyzed
 (i.e. with no column-based subsetting) that is passed by \code{rtables}.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{grade_groups}{(named \code{list} of \code{character})\cr containing groupings of grades.}
 

--- a/man/count_patients_events_in_cols.Rd
+++ b/man/count_patients_events_in_cols.Rd
@@ -27,9 +27,9 @@ summarize_patients_events_in_cols(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{filters_list}{(named \code{list} of \code{character})\cr each element in this list describes one
 type of event describe by filters, in the same format as \code{\link[=s_count_patients_with_event]{s_count_patients_with_event()}}.
@@ -56,7 +56,7 @@ be used as label.}
 Set to \code{FALSE} when the required column split has been done already earlier in the layout pipe.}
 }
 \value{
-\code{\link[=s_count_patients_and_multiple_events]{s_count_patients_and_multiple_events()}} returns a list with the statistics:\cr
+\code{\link[=s_count_patients_and_multiple_events]{s_count_patients_and_multiple_events()}} returns a list with the statistics:
 \itemize{
 \item \code{unique}: number of unique patients in \code{df}.
 \item \code{all}: number of rows in \code{df}.
@@ -80,7 +80,6 @@ statistics of patients and events in the column layout as content rows.
 
 }}
 \examples{
-
 # `s_count_patients_and_multiple_events()`
 df <- data.frame(
   USUBJID = rep(c("id1", "id2", "id3", "id4"), c(2, 3, 1, 1)),

--- a/man/count_patients_with_event.Rd
+++ b/man/count_patients_with_event.Rd
@@ -69,7 +69,7 @@ count_patients_with_flags(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{character})\cr name of the column that contains the unique identifier.}
 
@@ -84,10 +84,12 @@ Note that only equality is being accepted as condition.}
 
 \item{.N_row}{(\code{count})\cr column-wise N (column count) for the full column that is passed by \code{rtables}.}
 
-\item{denom}{(\code{string})\cr choice of denominator for proportion:\cr
-can be \code{n} (number of values in this row and column intersection), \code{N_row} (total
-number of values in this row across columns), or \code{N_col} (total number of values in
-this column across rows).}
+\item{denom}{(\code{string})\cr choice of denominator for proportion. Options are:
+\itemize{
+\item \code{n}: number of values in this row and column intersection.
+\item \code{N_row}: total number of values in this row across columns.
+\item \code{N_col}: total number of values in this column across rows.
+}}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 

--- a/man/count_values_funs.Rd
+++ b/man/count_values_funs.Rd
@@ -58,10 +58,12 @@ count_values(
 
 \item{.N_row}{(\code{count})\cr column-wise N (column count) for the full column that is passed by \code{rtables}.}
 
-\item{denom}{(\code{string})\cr choice of denominator for proportion:\cr
-can be \code{n} (number of values in this row and column intersection), \code{N_row} (total
-number of values in this row across columns), or \code{N_col} (total number of values in
-this column across rows).}
+\item{denom}{(\code{string})\cr choice of denominator for proportion. Options are:
+\itemize{
+\item \code{n}: number of values in this row and column intersection.
+\item \code{N_row}: total number of values in this row across columns.
+\item \code{N_col}: total number of values in this column across rows.
+}}
 
 \item{...}{additional arguments for the lower level functions.}
 

--- a/man/cox_regression.Rd
+++ b/man/cox_regression.Rd
@@ -16,7 +16,7 @@ summarize_coxreg(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}

--- a/man/cox_regression_inter.Rd
+++ b/man/cox_regression_inter.Rd
@@ -46,14 +46,12 @@ h_coxreg_inter_estimations(
 \item{at}{(\code{list})\cr a list with items named after the covariate, every
 item is a vector of levels at which the interaction should be estimated.}
 
-\item{data}{(\verb{data frame})\cr the data frame on which the model was fit.}
+\item{data}{(\code{data.frame})\cr the data frame on which the model was fit.}
 
-\item{variable, given}{(\code{string})\cr
-the name of variables in interaction. We seek the estimation of the levels
-of \code{variable} given the levels of \code{given}.}
+\item{variable, given}{(\code{string})\cr the name of variables in interaction. We seek the estimation
+of the levels of \code{variable} given the levels of \code{given}.}
 
-\item{lvl_var, lvl_given}{(\code{character})\cr
-corresponding levels has given by \code{\link[=levels]{levels()}}.}
+\item{lvl_var, lvl_given}{(\code{character})\cr corresponding levels has given by \code{\link[=levels]{levels()}}.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 }
@@ -61,10 +59,10 @@ corresponding levels has given by \code{\link[=levels]{levels()}}.}
 A list of matrix (one per level of variable) with rows corresponding to the combinations of
 \code{variable} and \code{given}, with columns:
 \describe{
-\item{coef_hat}{Estimation of the coefficient}
+\item{coef_hat}{Estimation of the coefficient.}
 \item{coef_se}{Standard error of the estimation.}
 \item{hr}{Hazard ratio.}
-\item{lcl,ucl}{lower/upper confidence limit of the hazard ratio}
+\item{lcl, ucl}{Lower/upper confidence limit of the hazard ratio.}
 }
 }
 \description{
@@ -79,8 +77,8 @@ Given the cox regression investigating the effect of Arm (A, B, C; reference A)
 and Sex (F, M; reference Female) and the model being abbreviated: y ~ Arm + Sex + Arm:Sex.
 The cox regression estimates the coefficients along with a variance-covariance matrix for:
 \itemize{
-\item b1 (arm b), b2 (arm c),
-\item b3 (sex m),
+\item b1 (arm b), b2 (arm c)
+\item b3 (sex m)
 \item b4 (arm b: sex m), b5 (arm c: sex m)
 }
 
@@ -148,4 +146,5 @@ result <- h_coxreg_inter_estimations(
   mod = mod, conf_level = .95
 )
 result
+
 }

--- a/man/d_proportion.Rd
+++ b/man/d_proportion.Rd
@@ -9,13 +9,11 @@ d_proportion(conf_level, method, long = FALSE)
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string}) \cr
-the method used to construct the confidence interval for proportion of
-successful outcomes; one of \code{waldcc}, \code{wald}, \code{clopper-pearson}, \code{wilson},
-\code{wilsonc}, \code{strat_wilson}, \code{strat_wilsonc}, \code{agresti-coull} or \code{jeffreys}.}
+\item{method}{(\code{string})\cr the method used to construct the confidence interval
+for proportion of successful outcomes; one of \code{waldcc}, \code{wald}, \code{clopper-pearson},
+\code{wilson}, \code{wilsonc}, \code{strat_wilson}, \code{strat_wilsonc}, \code{agresti-coull} or \code{jeffreys}.}
 
-\item{long}{(\code{flag})\cr
-whether a long or a short (default) description is required.}
+\item{long}{(\code{flag})\cr whether a long or a short (default) description is required.}
 }
 \value{
 String describing the analysis.

--- a/man/d_proportion_diff.Rd
+++ b/man/d_proportion_diff.Rd
@@ -9,11 +9,9 @@ d_proportion_diff(conf_level, method, long = FALSE)
 \arguments{
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string})\cr
-the method used for the confidence interval estimation.}
+\item{method}{(\code{string})\cr the method used for the confidence interval estimation.}
 
-\item{long}{(\code{logical})\cr
-Whether a long or a short (default) description is required.}
+\item{long}{(\code{logical})\cr Whether a long or a short (default) description is required.}
 }
 \value{
 String describing the analysis.

--- a/man/d_rsp_subgroups_colvars.Rd
+++ b/man/d_rsp_subgroups_colvars.Rd
@@ -11,10 +11,8 @@ d_rsp_subgroups_colvars(vars, conf_level = NULL, method = NULL)
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string})\cr
-specifies the test used to calculate the p-value for the difference between
-two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL}
-so no test is performed.}
+\item{method}{(\code{string})\cr specifies the test used to calculate the p-value for the difference between
+two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL} so no test is performed.}
 }
 \value{
 \code{list} of variables to tabulate and their labels.

--- a/man/d_test_proportion_diff.Rd
+++ b/man/d_test_proportion_diff.Rd
@@ -7,8 +7,7 @@
 d_test_proportion_diff(method)
 }
 \arguments{
-\item{method}{(\code{string})\cr
-one of (\code{chisq}, \code{cmh}, \code{fisher}, \code{schouten}; specifies the test used
+\item{method}{(\code{string})\cr one of \code{chisq}, \code{cmh}, \code{fisher}, or \code{schouten}; specifies the test used
 to calculate the p-value.}
 }
 \value{

--- a/man/desctools_binom.Rd
+++ b/man/desctools_binom.Rd
@@ -32,34 +32,35 @@ desctools_binomci(
 )
 }
 \arguments{
-\item{conf.level}{\cr confidence level, defaults to 0.95}
+\item{conf.level}{(\code{proportion})\cr confidence level, defaults to 0.95.}
 
-\item{sides}{\cr a character string specifying the side of the confidence interval. Must be one of "two-sided" (default), "left" or "right".}
+\item{sides}{(\code{character})\cr side of the confidence interval to compute. Must be one of "two-sided" (default),
+"left", or "right".}
 
-\item{method}{\cr character string specifying which method to use. Can be one out of: "wald", "wilson", "wilsoncc", "agresti-coull", "jeffreys", "modified wilson", "modified jeffreys", "clopper-pearson", "arcsine.
-", "logit", "witting", "pratt", "midp", "lik" and "blaker"
+\item{method}{(\code{character})\cr method to use. Can be one out of: "wald", "wilson", "wilsoncc", "agresti-coull",
+"jeffreys", "modified wilson", "modified jeffreys", "clopper-pearson", "arcsine", "logit", "witting", "pratt",
+"midp", "lik", and "blaker".}
 
-@return A matric with 3 columns containing:
-\itemize{
-\item \code{est}: estimate of proportion difference.
-\item \code{lwrci}: lower end of the confidence interval
-\item \code{upci}:  upper end of the confidence interval.
-}}
+\item{x}{(\code{count})\cr number of successes}
 
-\item{x}{\cr number of successes}
+\item{n}{(\code{count})\cr number of trials}
 
-\item{n}{\cr number of trials}
-
-\item{grp}{(\code{factor})\cr
-vector assigning observations to one out of two groups
+\item{grp}{(\code{factor})\cr vector assigning observations to one out of two groups
 (e.g. reference and treatment group).}
 }
 \value{
 A named list of 3 values:
-\itemize{
-\item \code{est}: estimate of proportion difference.
-\item \code{lwrci}: estimate of lower end of the confidence interval
-\item \code{upci}: estimate of upper end of the confidence interval.
+\describe{
+\item{est}{estimate of proportion difference.}
+\item{lwrci}{estimate of lower end of the confidence interval.}
+\item{upci}{estimate of upper end of the confidence interval.}
+}
+
+A matrix with 3 columns containing:
+\describe{
+\item{est}{estimate of proportion difference.}
+\item{lwrci}{lower end of the confidence interval.}
+\item{upci}{upper end of the confidence interval.}
 }
 }
 \description{
@@ -77,9 +78,8 @@ Several confidence intervals for the difference between proportions.
 
 }}
 \examples{
-# Internal function -
+# Internal function - desctools_binom
 \dontrun{
-
 set.seed(2)
 rsp <- sample(c(TRUE, FALSE), replace = TRUE, size = 20)
 grp <- factor(c(rep("A", 10), rep("B", 10)))

--- a/man/df_explicit_na.Rd
+++ b/man/df_explicit_na.Rd
@@ -13,7 +13,7 @@ df_explicit_na(
 )
 }
 \arguments{
-\item{data}{(\verb{data frame})\cr data set.}
+\item{data}{(\code{data.frame})\cr data set.}
 
 \item{omit_columns}{(\code{character})\cr names of variables from \code{data} that should
 not be modified by this function.}

--- a/man/estimate_coef.Rd
+++ b/man/estimate_coef.Rd
@@ -17,7 +17,7 @@ estimate_coef(
 }
 \arguments{
 \item{variable, given}{Names of two variable in interaction. We seek the estimation of the levels of \code{variable}
-given the levels of \code{given}}
+given the levels of \code{given}.}
 
 \item{lvl_var, lvl_given}{corresponding levels has given by \code{levels}.}
 
@@ -33,10 +33,10 @@ given the levels of \code{given}}
 A list of matrix (one per level of variable) with rows corresponding to the combinations of
 \code{variable} and \code{given}, with columns:
 \describe{
-\item{coef_hat}{Estimation of the coefficient}
+\item{coef_hat}{Estimation of the coefficient.}
 \item{coef_se}{Standard error of the estimation.}
 \item{hr}{Hazard ratio.}
-\item{lcl,ucl}{lower/upper confidence limit of the hazard ratio}
+\item{lcl, ucl}{Lower/upper confidence limit of the hazard ratio.}
 }
 }
 \description{
@@ -48,8 +48,8 @@ Given the cox regression investigating the effect of Arm (A, B, C; reference A)
 and Sex (F, M; reference Female). The model is abbreviated: y ~ Arm + Sex + Arm x Sex.
 The cox regression estimates the coefficients along with a variance-covariance matrix for:
 \itemize{
-\item b1 (arm b), b2 (arm c),
-\item b3 (sex m),
+\item b1 (arm b), b2 (arm c)
+\item b3 (sex m)
 \item b4 (arm b: sex m), b5 (arm c: sex m)
 }
 

--- a/man/estimate_proportions.Rd
+++ b/man/estimate_proportions.Rd
@@ -44,12 +44,11 @@ estimate_proportion(
 )
 }
 \arguments{
-\item{df}{(\code{logical} or \code{data.frame})\cr
-if only a logical vector is used, it indicates whether each subject is a
-responder or not. \code{TRUE} represents a successful outcome. If a \code{data.frame}
-is provided, also the \code{strata} variable names must be provided in
-\code{variables} as a list element with the strata strings. In the case of
-\code{data.frame}, the logical vector of responses must be indicated as a
+\item{df}{(\code{logical} or \code{data.frame})\cr if only a logical vector is used,
+it indicates whether each subject is a responder or not. \code{TRUE} represents
+a successful outcome. If a \code{data.frame} is provided, also the \code{strata} variable
+names must be provided in \code{variables} as a list element with the strata strings.
+In the case of \code{data.frame}, the logical vector of responses must be indicated as a
 variable name in \code{.var}.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
@@ -57,19 +56,15 @@ by a statistics function.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string}) \cr
-the method used to construct the confidence interval for proportion of
-successful outcomes; one of \code{waldcc}, \code{wald}, \code{clopper-pearson}, \code{wilson},
-\code{wilsonc}, \code{strat_wilson}, \code{strat_wilsonc}, \code{agresti-coull} or \code{jeffreys}.}
+\item{method}{(\code{string})\cr the method used to construct the confidence interval
+for proportion of successful outcomes; one of \code{waldcc}, \code{wald}, \code{clopper-pearson},
+\code{wilson}, \code{wilsonc}, \code{strat_wilson}, \code{strat_wilsonc}, \code{agresti-coull} or \code{jeffreys}.}
 
-\item{weights}{(\code{numeric} or \code{NULL}) \cr
-weights for each level of the strata. If \code{NULL}, they are
-estimated using the iterative algorithm proposed in
-\insertCite{Yan2010-jt;textual}{tern} that minimizes the weighted squared
-length of the confidence interval.}
+\item{weights}{(\code{numeric} or \code{NULL})\cr weights for each level of the strata. If \code{NULL}, they are
+estimated using the iterative algorithm proposed in \insertCite{Yan2010-jt;textual}{tern} that
+minimizes the weighted squared length of the confidence interval.}
 
-\item{max_iterations}{(\code{count}) \cr
-maximum number of iterations for the iterative procedure used
+\item{max_iterations}{(\code{count})\cr maximum number of iterations for the iterative procedure used
 to find estimates of optimal weights.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
@@ -112,7 +107,6 @@ proportion along with its confidence interval.
 
 }}
 \examples{
-
 # Case with only logical vector.
 rsp_v <- c(1, 0, 1, 0, 1, 1, 0, 0)
 s_proportion(rsp_v)

--- a/man/extract_rsp_subgroups.Rd
+++ b/man/extract_rsp_subgroups.Rd
@@ -24,10 +24,8 @@ levels that belong to it in the character vectors that are elements of the list.
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string})\cr
-specifies the test used to calculate the p-value for the difference between
-two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL}
-so no test is performed.}
+\item{method}{(\code{string})\cr specifies the test used to calculate the p-value for the difference between
+two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL} so no test is performed.}
 
 \item{label_all}{(\code{string})\cr label for the total population analysis.}
 }

--- a/man/extract_survival_subgroups.Rd
+++ b/man/extract_survival_subgroups.Rd
@@ -21,15 +21,14 @@ extract_survival_subgroups(
 list, which specifies the new group levels via the names and the
 levels that belong to it in the character vectors that are elements of the list.}
 
-\item{control}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for comparison details, specified by using the helper function
+\code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
-Default method is "log-rank" which comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood"
-that comes from \code{\link[survival:coxph]{survival::coxph()}}.
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1. Default method is "log-rank" which
+comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood" (from \code{\link[survival:coxph]{survival::coxph()}}).
+\item \code{ties} (\code{string})\cr specifying the method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 
 \item{label_all}{(\code{string})\cr label for the total population analysis.}

--- a/man/fit_coxreg.Rd
+++ b/man/fit_coxreg.Rd
@@ -17,7 +17,7 @@ in \code{data}, passed as a named list and corresponding to \code{time}, \code{e
 only Cox model(s) including the \code{covariates} will be fitted and the corresponding
 effect estimates will be tabulated later.}
 
-\item{data}{(\verb{data frame})\cr the dataset containing the variables to fit the
+\item{data}{(\code{data.frame})\cr the dataset containing the variables to fit the
 models.}
 
 \item{at}{(\code{list} of \code{numeric})\cr when the candidate covariate is a
@@ -30,21 +30,21 @@ helper function \code{\link[=control_coxreg]{control_coxreg()}}.}
 \value{
 The function \code{fit_coxreg_univar} returns a \code{coxreg.univar} class object which is a named list
 with 5 elements:
-\itemize{
-\item \code{mod}: Cox regression models fitted by \code{\link[survival:coxph]{survival::coxph()}}.
-\item \code{data}: The original data frame input.
-\item \code{control}: The original control input.
-\item \code{vars}: The variables used in the model.
-\item \code{at}: Value of the covariate at which the effect should be estimated.
+\describe{
+\item{mod}{Cox regression models fitted by \code{\link[survival:coxph]{survival::coxph()}}.}
+\item{data}{The original data frame input.}
+\item{control}{The original control input.}
+\item{vars}{The variables used in the model.}
+\item{at}{Value of the covariate at which the effect should be estimated.}
 }
 
 The function \code{fit_coxreg_multivar} returns a \code{coxreg.multivar} class object which is a named list
 with 4 elements:
-\itemize{
-\item \code{mod}: Cox regression model fitted by \code{\link[survival:coxph]{survival::coxph()}}.
-\item \code{data}: The original data frame input.
-\item \code{control}: The original control input.
-\item \code{vars}: The variables used in the model.
+\describe{
+\item{mod}{Cox regression model fitted by \code{\link[survival:coxph]{survival::coxph()}}.}
+\item{data}{The original data frame input.}
+\item{control}{The original control input.}
+\item{vars}{The variables used in the model.}
 }
 }
 \description{
@@ -133,6 +133,7 @@ mod4 <- fit_coxreg_univar(
   ),
   data = dta_bladder
 )
+
 # fit_coxreg_multivar
 
 ## Cox regression: multivariate Cox regression.
@@ -152,6 +153,7 @@ multivar_covs_model <- fit_coxreg_multivar(
   ),
   data = dta_bladder
 )
+
 }
 \seealso{
 \link{h_cox_regression} for relevant helper functions, \link{cox_regression}.

--- a/man/fit_logistic.Rd
+++ b/man/fit_logistic.Rd
@@ -12,7 +12,7 @@ fit_logistic(
 )
 }
 \arguments{
-\item{data}{(\verb{data frame})\cr the data frame on which the model was fit.}
+\item{data}{(\code{data.frame})\cr the data frame on which the model was fit.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 
@@ -25,22 +25,17 @@ side of the formula.}
 
 Fit a (conditional) logistic regression model.
 }
-\details{
-Note this function may hang or error for certain datasets when an old version of the
-survival package (< 3.2-13) is used.
-}
 \section{Model Specification}{
 
 
-The \code{variables} list needs to include the following elements:\cr
-\itemize{
-\item \code{arm}: usual treatment arm variable name.
-\item \code{response}: the response arm variable name. Usually this is a 0/1 variable.
-\item \code{covariates}: this is either \code{NULL} (no covariates) or
-a character vector of covariate variable names.
-\item \code{interaction}: this is either \code{NULL} (no interaction) or a string of a single
-covariate variable name already included in \code{covariates}. Then the interaction
-with the treatment arm is included in the model.
+The \code{variables} list needs to include the following elements:
+\describe{
+\item{arm}{treatment arm variable name.}
+\item{response}{the response arm variable name. Usually this is a 0/1 variable.}
+\item{covariates}{this is either \code{NULL} (no covariates) or a character vector of covariate variable names.}
+\item{interaction}{this is either \code{NULL} (no interaction) or a string of a single covariate variable name already
+included in \code{covariates}. Then the interaction with the treatment arm is included in the model.
+}
 }
 }
 
@@ -73,4 +68,5 @@ mod2 <- fit_logistic(
     interaction = "AGE"
   )
 )
+
 }

--- a/man/fit_rsp_step.Rd
+++ b/man/fit_rsp_step.Rd
@@ -30,8 +30,10 @@ This fits the Subgroup Treatment Effect Pattern logistic regression models for a
 where the first one is taken as reference and the estimated odds ratios are
 for the comparison of the second level vs. the first one.
 
-The (conditional) logistic regression model which is fit is:\cr
-\code{response ~ arm * poly(biomarker, degree) + covariates + strata(strata)}\cr
+The (conditional) logistic regression model which is fit is:
+
+\code{response ~ arm * poly(biomarker, degree) + covariates + strata(strata)}
+
 where \code{degree} is specified by \code{control_step()}.
 Note that for the default degree 0 the \code{biomarker} variable is not included in the model.
 }

--- a/man/fit_survival_step.Rd
+++ b/man/fit_survival_step.Rd
@@ -30,8 +30,10 @@ This fits the Subgroup Treatment Effect Pattern models for a survival outcome. T
 variable must have exactly 2 levels, where the first one is taken as reference and the estimated
 hazard ratios are for the comparison of the second level vs. the first one.
 
-The model which is fit is:\cr
-\code{Surv(time, event) ~ arm * poly(biomarker, degree) + covariates + strata(strata)}\cr
+The model which is fit is:
+
+\code{Surv(time, event) ~ arm * poly(biomarker, degree) + covariates + strata(strata)}
+
 where \code{degree} is specified by \code{control_step()}.
 Note that for the default degree 0 the \code{biomarker} variable is not included in the model.
 }

--- a/man/g_forest.Rd
+++ b/man/g_forest.Rd
@@ -31,11 +31,9 @@ g_forest(
 \item{col_ci}{(\code{integer})\cr column index with confidence intervals. By default tries
 to get this from \code{tbl} attribute \code{col_ci}, otherwise needs to be manually specified.}
 
-\item{vline}{(\code{number})\cr
-x coordinate for vertical line, if \code{NULL} then the line is omitted.}
+\item{vline}{(\code{number})\cr x coordinate for vertical line, if \code{NULL} then the line is omitted.}
 
-\item{forest_header}{(\code{character}, length 2)\cr
-text displayed to the left and right of \code{vline}, respectively.
+\item{forest_header}{(\code{character}, length 2)\cr text displayed to the left and right of \code{vline}, respectively.
 If \code{vline = NULL} then \code{forest_header} needs to be \code{NULL} too.
 By default tries to get this from \code{tbl} attribute \code{forest_header}.}
 
@@ -45,21 +43,19 @@ By default tries to get this from \code{tbl} attribute \code{forest_header}.}
 
 \item{x_at}{(\code{numeric})\cr x-tick locations, if \code{NULL} they get automatically chosen.}
 
-\item{width_row_names}{(\code{unit})\cr
-width for row names. If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
+\item{width_row_names}{(\code{unit})\cr width for row names.
+If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
 
-\item{width_columns}{(\code{unit})\cr
-widths for the table columns. If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
+\item{width_columns}{(\code{unit})\cr widths for the table columns.
+If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
 
-\item{width_forest}{(\code{unit})\cr
-width for the forest column. If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
+\item{width_forest}{(\code{unit})\cr width for the forest column.
+If \code{NULL} the widths get automatically calculated. See \code{\link[grid:unit]{grid::unit()}}.}
 
-\item{col_symbol_size}{(\code{integer})\cr
-column index from \code{tbl} containing data to be used to determine relative
-size for estimator plot symbol. Typically, the symbol size is proportional to the
-sample size used to calculate the estimator. If \code{NULL}, the same symbol
-size is used for all subgroups. By default tries to get this from
-\code{tbl} attribute \code{col_symbol_size}, otherwise needs to be manually specified.}
+\item{col_symbol_size}{(\code{integer})\cr column index from \code{tbl} containing data to be used
+to determine relative size for estimator plot symbol. Typically, the symbol size is proportional
+to the sample size used to calculate the estimator. If \code{NULL}, the same symbol size is used for all subgroups.
+By default tries to get this from \code{tbl} attribute \code{col_symbol_size}, otherwise needs to be manually specified.}
 
 \item{col}{(\code{character})\cr color(s).}
 
@@ -69,7 +65,7 @@ size is used for all subgroups. By default tries to get this from
 Only considered if \code{draw = TRUE} is used.}
 }
 \value{
-(\code{gtree}) object containing the forest plot and table
+\code{gtree} object containing the forest plot and table
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/g_km.Rd
+++ b/man/g_km.Rd
@@ -40,21 +40,21 @@ g_km(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{variables}{(named \code{list}) of variable names. Details are: \cr
+\item{variables}{(named \code{list})\cr variable names. Details are:
 \itemize{
-\item \code{tte}: variable indicating time-to-event duration values (\code{numeric}).
-\item \code{is_event}: event variable (\code{logical}) \cr \code{TRUE} if event, \code{FALSE} if time to event is censored.
-\item \code{arm}: the treatment group variable (\code{factor}).
-\item \code{strat}: (\code{character} or \code{NULL}) variable names indicating stratification factors.
+\item \code{tte} (\code{numeric})\cr variable indicating time-to-event duration values.
+\item \code{is_event} (\code{logical})\cr event variable. \code{TRUE} if event, \code{FALSE} if time to event is censored.
+\item \code{arm} (\code{factor})\cr the treatment group variable.
+\item \code{strat} (\code{character} or \code{NULL})\cr variable names indicating stratification factors.
 }}
 
-\item{control_surv}{a (\code{list}) of parameters for comparison details, specified by using \cr
-the helper function \code{\link{control_surv_timepoint}}. Some possible parameter options are: \cr
+\item{control_surv}{(\code{list})\cr parameters for comparison details, specified by using
+the helper function \code{\link{control_surv_timepoint}}. Some possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for survival rate.
-\item \code{conf_type}: (\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for survival rate.
+\item \code{conf_type} (\code{string})\cr "plain" (default), "log", "log-log" for confidence interval type,
 see more in \code{\link[survival:survfit]{survival::survfit()}}. Note that the option "none" is no longer supported.
 }}
 
@@ -73,20 +73,16 @@ to number of strata from \code{\link[survival:survfit]{survival::survfit()}}.}
 
 \item{size}{(\code{numeric})\cr size of censored point, a class of \code{unit}.}
 
-\item{max_time}{(\code{numeric})\cr maximum value to show on X axis.
-Only data values less than or up to to this threshold value will be plotted.(\code{NULL} for
-default)}
+\item{max_time}{(\code{numeric})\cr maximum value to show on X axis. Only data values less than or up to
+this threshold value will be plotted (defaults to \code{NULL}).}
 
-\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr
-numeric vector of ticks or single number with spacing
-between ticks on the x axis.
-If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
+\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr numeric vector of ticks or single number with spacing
+between ticks on the x axis. If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
 an optimal tick position on the x axis.}
 
 \item{xlab}{(\code{string})\cr label of x-axis.}
 
-\item{yval}{(\code{string})\cr value of y-axis. Should be either
-\code{Survival} (default) or \code{Failure} probability.}
+\item{yval}{(\code{string})\cr value of y-axis. Options are \code{Survival} (default) and \code{Failure} probability.}
 
 \item{ylab}{(\code{string})\cr label of y-axis.}
 
@@ -108,19 +104,17 @@ Only considered if \code{draw = TRUE} is used.}
 \item{name}{a character identifier for the grob.  Used to find the
     grob on the display list and/or as a child of another grob. }
 
-\item{font_size}{(\code{number}) \cr font size to be used.}
+\item{font_size}{(\code{number})\cr font size to be used.}
 
 \item{ci_ribbon}{(\code{flag})\cr draw the confidence interval around the Kaplan-Meier curve.}
 
-\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to
-control outlook of the Kaplan-Meier curve.}
+\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to control outlook of the Kaplan-Meier curve.}
 
-\item{annot_at_risk}{(\code{flag})\cr compute and add the annotation table
-reporting the number of patient at risk matching the main grid of the
-Kaplan-Meier curve.}
+\item{annot_at_risk}{(\code{flag})\cr compute and add the annotation table reporting the number of patient at risk
+matching the main grid of the Kaplan-Meier curve.}
 
-\item{annot_surv_med}{(\code{flag})\cr compute and add the annotation table
-on the Kaplan-Meier curve estimating the median survival time per group.}
+\item{annot_surv_med}{(\code{flag})\cr compute and add the annotation table on the Kaplan-Meier curve estimating the
+median survival time per group.}
 
 \item{annot_coxph}{(\code{flag})\cr add the annotation table from a \code{\link[survival:coxph]{survival::coxph()}} model.}
 
@@ -130,20 +124,20 @@ on the Kaplan-Meier curve estimating the median survival time per group.}
 \item{annot_stats_vlines}{(\code{flag})\cr add vertical lines corresponding to each of the statistics
 specified by \code{annot_stats}. If \code{annot_stats} is \code{NULL} no lines will be added.}
 
-\item{control_coxph_pw}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control_coxph_pw}{(\code{list})\cr parameters for comparison details, specified by using
+the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1.
 Default method is "log-rank", can also be set to "wald" or "likelihood".
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{ties} (\code{string})\cr method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 
-\item{position_coxph}{\code{numeric} \cr x and y positions for plotting \code{\link[survival:coxph]{survival::coxph()}} model.}
+\item{position_coxph}{(\code{numeric})\cr x and y positions for plotting \code{\link[survival:coxph]{survival::coxph()}} model.}
 
-\item{position_surv_med}{\code{numeric} \cr x and y positions for plotting annotation table
-estimating median survival time per group}
+\item{position_surv_med}{(\code{numeric})\cr x and y positions for plotting annotation table estimating median survival
+time per group.}
 }
 \value{
 a \code{grob} of class \code{gTree}.

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -36,100 +36,87 @@ g_lineplot(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame}) \cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{alt_counts_df}{(\verb{data frame} or \code{NULL}) \cr
-data set that will be used (only) to counts objects in strata.}
+\item{alt_counts_df}{(\code{data.frame} or \code{NULL})\cr data set that will be used (only) to counts objects in strata.}
 
-\item{variables}{(named \code{character} vector) of variable names in \code{df} data set. Details are: \cr
+\item{variables}{(named \code{character} vector) of variable names in \code{df} data set. Details are:
 \itemize{
-\item \code{x}: x-axis variable.
-\item \code{y}: y-axis variable.
-\item \code{strata}: grouping variable, i.e. treatment arm. Can be \code{NA} to indicate lack of groups.
-\item \code{paramcd}: the variable name for parameter's code. Used for y-axis label and plot's subtitle.
+\item \code{x} (\code{character})\cr name of x-axis variable.
+\item \code{y} (\code{character})\cr name of y-axis variable.
+\item \code{strata} (\code{character})\cr name of grouping variable, i.e. treatment arm. Can be \code{NA} to indicate lack of groups.
+\item \code{paramcd} (\code{character})\cr name of the variable for parameter's code. Used for y-axis label and plot's subtitle.
 Can be \code{NA} if paramcd is not to be added to the y-axis label or subtitle.
-\item \code{y_unit}: variable with units of \code{y}. Used for y-axis label and plot's subtitle.
+\item \code{y_unit} (\code{character})\cr name of variable with units of \code{y}. Used for y-axis label and plot's subtitle.
 Can be \code{NA} if y unit is not to be added to the y-axis label or subtitle.
 }}
 
-\item{mid}{(\code{character} or \code{NULL}) \cr
-names of the statistics that will be plotted as midpoints.
+\item{mid}{(\code{character} or \code{NULL})\cr names of the statistics that will be plotted as midpoints.
 All the statistics indicated in \code{mid} variable must be present in the object returned by \code{sfun},
 and be of a \code{double} or \code{numeric} type vector of length one.}
 
-\item{interval}{(\code{character} or \code{NULL}) \cr
-names of the statistics that will be plotted as intervals.
+\item{interval}{(\code{character} or \code{NULL})\cr names of the statistics that will be plotted as intervals.
 All the statistics indicated in \code{interval} variable must be present in the object returned by \code{sfun},
 and be of a \code{double} or \code{numeric} type vector of length two.}
 
-\item{whiskers}{(\code{character}) \cr
-names of the interval whiskers that will be plotted. Must match the \code{names} attribute of the
-\code{interval} element in the list returned by \code{sfun}.
-It is possible to specify one whisker only, lower or upper.}
+\item{whiskers}{(\code{character})\cr names of the interval whiskers that will be plotted. Must match the \code{names}
+attribute of the \code{interval} element in the list returned by \code{sfun}. It is possible to specify one whisker only,
+lower or upper.}
 
-\item{table}{(\code{character} or \code{NULL}) \cr
-names of the statistics that will be displayed in the table below the plot.
+\item{table}{(\code{character} or \code{NULL})\cr names of the statistics that will be displayed in the table below the plot.
 All the statistics indicated in \code{table} variable must be present in the object returned by \code{sfun}.}
 
-\item{sfun}{(\code{closure}) \cr the function to compute the values of required statistics.
-It must return a named \code{list} with atomic vectors.
-The names of the \code{list} elements refer to the names of the statistics
-and are used by \code{mid}, \code{interval}, \code{table}.
-It must be able to accept as input a vector with data for which statistics are computed.}
+\item{sfun}{(\code{closure})\cr the function to compute the values of required statistics. It must return a named \code{list}
+with atomic vectors. The names of the \code{list} elements refer to the names of the statistics and are used by \code{mid},
+\code{interval}, \code{table}. It must be able to accept as input a vector with data for which statistics are computed.}
 
 \item{...}{optional arguments to \code{sfun}.}
 
-\item{mid_type}{(\code{character} scalar) \cr
-controls the type of the \code{mid} plot, it can be point (\code{p}), line (\code{l}), or point and line (\code{pl}).}
+\item{mid_type}{(\code{character})\cr controls the type of the \code{mid} plot, it can be point (\code{p}), line (\code{l}),
+or point and line (\code{pl}).}
 
-\item{mid_point_size}{(\code{integer} or \code{double}) \cr
-controls the font size of the point for \code{mid} plot.}
+\item{mid_point_size}{(\code{integer} or \code{double})\cr controls the font size of the point for \code{mid} plot.}
 
-\item{position}{(\code{character} or \code{call}) \cr
-geom element position adjustment, either as a string, or the result of a call to a position adjustment function.}
+\item{position}{(\code{character} or \code{call})\cr geom element position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
-\item{legend_title}{(\code{character} string) \cr legend title.}
+\item{legend_title}{(\code{character} string)\cr legend title.}
 
-\item{legend_position}{(\code{character}) \cr
-the position of the plot legend (\code{none}, \code{left}, \code{right}, \code{bottom}, \code{top}, or two-element numeric vector).}
+\item{legend_position}{(\code{character})\cr the position of the plot legend (\code{none}, \code{left}, \code{right}, \code{bottom}, \code{top},
+or two-element numeric vector).}
 
-\item{ggtheme}{(\code{theme}) \cr
-a graphical theme as provided by \code{ggplot2} to control outlook of the plot.}
+\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to control styling of the plot.}
 
-\item{y_lab}{(\code{character} scalar) \cr y-axis label.
-If it equals to \code{NULL}, then no label will be added.}
+\item{y_lab}{(\code{character})\cr y-axis label. If equal to \code{NULL}, then no label will be added.}
 
-\item{y_lab_add_paramcd}{(\code{logical} scalar) \cr
-should paramcd, i.e. \code{unique(df[[variables["paramcd"]]])} be added to the y-axis label \code{y_lab}?}
+\item{y_lab_add_paramcd}{(\code{logical})\cr should paramcd, i.e. \code{unique(df[[variables["paramcd"]]])} be added to the
+y-axis label \code{y_lab}?}
 
-\item{y_lab_add_unit}{(\code{logical} scalar) \cr
-should y unit, i.e. \code{unique(df[[variables["y_unit"]]])} be added to the y-axis label \code{y_lab}?}
+\item{y_lab_add_unit}{(\code{logical})\cr should y unit, i.e. \code{unique(df[[variables["y_unit"]]])} be added to the y-axis
+label \code{y_lab}?}
 
-\item{title}{(\code{character} scalar) \cr plot title.}
+\item{title}{(\code{character})\cr plot title.}
 
-\item{subtitle}{(\code{character} scalar) \cr plot subtitle.}
+\item{subtitle}{(\code{character})\cr plot subtitle.}
 
-\item{subtitle_add_paramcd}{(\code{logical} scalar) \cr
-should paramcd, i.e. \code{unique(df[[variables["paramcd"]]])} be added to the plot's subtitle \code{subtitle}?}
+\item{subtitle_add_paramcd}{(\code{logical})\cr should paramcd, i.e. \code{unique(df[[variables["paramcd"]]])} be added to
+the plot's subtitle \code{subtitle}?}
 
-\item{subtitle_add_unit}{(\code{logical} scalar) \cr
-should y unit, i.e. \code{unique(df[[variables["y_unit"]]])} be added to the plot's subtitle \code{subtitle}?}
+\item{subtitle_add_unit}{(\code{logical})\cr should y unit, i.e. \code{unique(df[[variables["y_unit"]]])} be added to the
+plot's subtitle \code{subtitle}?}
 
-\item{caption}{(\code{character} scalar) \cr optional caption below the plot.}
+\item{caption}{(\code{character})\cr optional caption below the plot.}
 
-\item{table_format}{(named \code{character} or \code{NULL}) \cr
-format patterns for descriptive statistics used in the (optional) table appended to the plot.
-It is passed directly to the \code{h_format_row} function through the \code{format} parameter.
-Names of \code{table_format} must match the names of statistics returned by \code{sfun} function.}
+\item{table_format}{(named \code{character} or \code{NULL})\cr format patterns for descriptive statistics used in the
+(optional) table appended to the plot. It is passed directly to the \code{h_format_row} function through the \code{format}
+parameter. Names of \code{table_format} must match the names of statistics returned by \code{sfun} function.}
 
-\item{table_labels}{(named \code{character} or \code{NULL}) \cr
-labels for descriptive statistics used in the (optional) table appended to the plot.
-Names of \code{table_labels} must match the names of statistics returned by \code{sfun} function.}
+\item{table_labels}{(named \code{character} or \code{NULL})\cr labels for descriptive statistics used in the (optional) table
+appended to the plot. Names of \code{table_labels} must match the names of statistics returned by \code{sfun} function.}
 
-\item{table_font_size}{(\code{integer} or \code{double}) \cr
-controls the font size of values in the table.}
+\item{table_font_size}{(\code{integer} or \code{double})\cr controls the font size of values in the table.}
 
-\item{newpage}{(\code{logical} scalar) \cr should plot be drawn on new page?}
+\item{newpage}{(\code{logical})\cr should plot be drawn on new page?}
 
 \item{col}{(\code{character})\cr colors.}
 }
@@ -139,7 +126,7 @@ controls the font size of values in the table.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Line plot with the optional table
+Line plot with the optional table.
 }
 \examples{
 library(nestcolor)

--- a/man/g_waterfall.Rd
+++ b/man/g_waterfall.Rd
@@ -16,32 +16,24 @@ g_waterfall(
 )
 }
 \arguments{
-\item{height}{(\code{numeric} vector)\cr
-Contains values to be plotted as the waterfall bars}
+\item{height}{(`numeric``)\cr vector containing values to be plotted as the waterfall bars.}
 
-\item{id}{(vector)\cr
-Contains of IDs used as the x-axis label for the waterfall bars}
+\item{id}{(\code{character})\cr vector containing IDs to use as the x-axis label for the waterfall bars.}
 
-\item{col_var}{(\code{factor}, \code{character} or \code{NULL})\cr
-Categorical variable for bar coloring. \code{NULL} by default.}
+\item{col_var}{(\code{factor}, \code{character} or \code{NULL})\cr categorical variable for bar coloring. \code{NULL} by default.}
 
 \item{col}{(\code{character})\cr colors.}
 
-\item{xlab}{(\code{character} value)\cr
-x label. Default is \code{ID}.}
+\item{xlab}{(\code{character})\cr x label. Default is \code{"ID"}.}
 
-\item{ylab}{(\code{character} value)\cr
-y label. Default is \code{Value}.}
+\item{ylab}{(\code{character})\cr y label. Default is \code{"Value"}.}
 
-\item{col_legend_title}{(\code{character} value)\cr
-Text to be displayed as legend title.}
+\item{col_legend_title}{(\code{character})\cr text to be displayed as legend title.}
 
-\item{title}{(\code{character} value)\cr
-Text to be displayed as plot title.}
+\item{title}{(\code{character})\cr text to be displayed as plot title.}
 }
 \value{
-(\code{ggplot} object)\cr
-Waterfall plot
+(\code{ggplot} object)\cr waterfall plot.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/get_smooths.Rd
+++ b/man/get_smooths.Rd
@@ -7,7 +7,7 @@
 get_smooths(df, x, y, groups = NULL, level = 0.95)
 }
 \arguments{
-\item{df}{(\code{data.frame})\cr.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{x}{(\code{character})\cr value with x column name.}
 
@@ -15,7 +15,7 @@ get_smooths(df, x, y, groups = NULL, level = 0.95)
 
 \item{groups}{(\code{character})\cr vector with optional grouping variables names.}
 
-\item{level}{(\code{numeric}) level of confidence interval to use (0.95 by default).}
+\item{level}{(\code{numeric})\cr level of confidence interval to use (0.95 by default).}
 }
 \value{
 A \code{data.frame} with original \code{x}, smoothed \code{y}, \code{ylow}, \code{yhigh} and

--- a/man/h_adlb_worsen.Rd
+++ b/man/h_adlb_worsen.Rd
@@ -12,16 +12,13 @@ h_adlb_worsen(
 )
 }
 \arguments{
-\item{adlb}{(\verb{data frame}) \cr \code{ADLB} dataframe}
+\item{adlb}{(\code{data.frame})\cr \code{ADLB} dataframe}
 
-\item{worst_flag_low}{(named \code{vector}) \cr
-Worst low post-baseline lab grade flag variable}
+\item{worst_flag_low}{(named \code{vector})\cr Worst low post-baseline lab grade flag variable}
 
-\item{worst_flag_high}{(named \code{vector}) \cr
-Worst high post-baseline lab grade flag variable}
+\item{worst_flag_high}{(named \code{vector})\cr Worst high post-baseline lab grade flag variable}
 
-\item{direction_var}{(\code{string}) \cr
-Direction variable specifying the direction of the shift table of interest.
+\item{direction_var}{(\code{string})\cr Direction variable specifying the direction of the shift table of interest.
 Only lab records flagged by \code{L}, \code{H} or \code{B} are included in the shift table.
 \itemize{
 \item \code{L}: low direction only
@@ -30,7 +27,7 @@ Only lab records flagged by \code{L}, \code{H} or \code{B} are included in the s
 }}
 }
 \value{
-\code{\link[=h_adlb_worsen]{h_adlb_worsen()}} returns the \code{adlb} \verb{data frame} containing only the
+\code{\link[=h_adlb_worsen]{h_adlb_worsen()}} returns the \code{adlb} \code{data.frame} containing only the
 worst labs specified according to \code{worst_flag_low} or \code{worst_flag_high} for the
 direction specified according to \code{direction_var}. For instance, for a lab that is
 needed for the low direction only, only records flagged by \code{worst_flag_low} are

--- a/man/h_adsl_adlb_merge_using_worst_flag.Rd
+++ b/man/h_adsl_adlb_merge_using_worst_flag.Rd
@@ -13,24 +13,23 @@ h_adsl_adlb_merge_using_worst_flag(
 )
 }
 \arguments{
-\item{adsl}{(\verb{data frame}) \code{ADSL} dataframe}
+\item{adsl}{(\code{data.frame})\cr \code{ADSL} dataframe.}
 
-\item{adlb}{(\verb{data frame}) \code{ADLB} dataframe}
+\item{adlb}{(\code{data.frame})\cr \code{ADLB} dataframe.}
 
-\item{worst_flag}{(named \code{vector})
-Worst post-baseline lab flag variable}
+\item{worst_flag}{(named \code{vector})\cr Worst post-baseline lab flag variable.}
 
-\item{by_visit}{(\code{logical}) defaults to \code{FALSE} to generate worst grade per patient.
+\item{by_visit}{(\code{logical})\cr defaults to \code{FALSE} to generate worst grade per patient.
 If worst grade per patient per visit is specified for \code{worst_flag}, then
 \code{by_visit} should be \code{TRUE} to generate worst grade patient per visit.}
 
-\item{no_fillin_visits}{(named \code{character})
-Visits that are not considered for post-baseline worst toxicity grade. Defaults to \code{c("SCREENING", "BASELINE")}.}
+\item{no_fillin_visits}{(named \code{character})\cr Visits that are not considered for post-baseline worst toxicity
+grade. Defaults to \code{c("SCREENING", "BASELINE")}.}
 }
 \value{
 \code{df} containing variables shared between \code{adlb} and \code{adsl} along with variables relevant for analysis:
-\code{PARAM}, \code{PARAMCD}, \code{ATOXGR}, and \code{BTOXGR}.  Optionally \code{AVISIT}, \code{AVISITN} are included when \code{by_visit = TRUE} and
-\code{no_fillin_visits = c("SCREENING", "BASELINE")}.
+\code{PARAM}, \code{PARAMCD}, \code{ATOXGR}, and \code{BTOXGR}.  Optionally \code{AVISIT}, \code{AVISITN} are included when \code{by_visit = TRUE}
+and \code{no_fillin_visits = c("SCREENING", "BASELINE")}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
@@ -41,9 +40,9 @@ output dataset.
 \details{
 In the result data missing records will be created for the following situations:
 \itemize{
-\item patients who are present in \code{adsl} but have no lab data in \code{adlb} (both baseline and post-baseline)
-\item patients who do not have any post-baseline lab values
-\item patients without any post-baseline values flagged as the worst
+\item Patients who are present in \code{adsl} but have no lab data in \code{adlb} (both baseline and post-baseline).
+\item Patients who do not have any post-baseline lab values.
+\item Patients without any post-baseline values flagged as the worst.
 }
 }
 \examples{

--- a/man/h_ancova.Rd
+++ b/man/h_ancova.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/summarize_ancova.R
 \name{h_ancova}
 \alias{h_ancova}
-\title{Helper Function to Return Results of a Linear Model.}
+\title{Helper Function to Return Results of a Linear Model}
 \usage{
 h_ancova(.var, .df_row, variables, interaction_item = NULL)
 }
@@ -10,21 +10,21 @@ h_ancova(.var, .df_row, variables, interaction_item = NULL)
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.df_row}{(\verb{data frame})\cr data set that includes all the variables that are called
+\item{.df_row}{(\code{data.frame})\cr data set that includes all the variables that are called
 in \code{.var} and \code{variables}.}
 
 \item{variables}{(named \code{list} of \code{strings})\cr list of additional analysis variables, with
 expected elements:
 \itemize{
-\item \code{arm}: (\code{string})\cr group variable, for which the covariate adjusted means of multiple
+\item \code{arm} (\code{string})\cr group variable, for which the covariate adjusted means of multiple
 groups will be summarized. Specifically, the first level of \code{arm} variable is taken as the
 reference group.
-\item \code{covariates}: (\code{character})\cr a vector that can contain single variable names (such as
+\item \code{covariates} (\code{character})\cr a vector that can contain single variable names (such as
 \code{"X1"}), and/or interaction terms indicated by \code{"X1 * X2"}.
 }}
 
 \item{interaction_item}{(\code{character})\cr name of the variable that should have interactions
-with arm. if the interaction is not needed, the default option is NULL}
+with arm. if the interaction is not needed, the default option is NULL.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/h_count_cumulative.Rd
+++ b/man/h_count_cumulative.Rd
@@ -28,18 +28,18 @@ count, default is \code{TRUE}.}
 \item{.N_col}{(\code{count})\cr denominator for fraction calculation.}
 }
 \value{
-A named vector of 2:
-\itemize{
-\item \code{count}: the count of values less than, less or equal to, greater than, or
-greater or equal to a threshold of user specification.
-\item \code{fraction}: the fraction of the count.
+A named vector with items:
+\describe{
+\item{count}{the count of values less than, less or equal to, greater than, or greater or equal to a threshold
+of user specification.
+}
+\item{fraction}{the fraction of the count.}
 }
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Helper function to calculate count and fraction of
-\code{x} values in the lower or upper tail given a threshold.
+Helper function to calculate count and fraction of \code{x} values in the lower or upper tail given a threshold.
 }
 \examples{
 set.seed(1, kind = "Mersenne-Twister")

--- a/man/h_data_plot.Rd
+++ b/man/h_data_plot.Rd
@@ -9,12 +9,11 @@ h_data_plot(fit_km, armval = "All", max_time = NULL)
 \arguments{
 \item{fit_km}{(\code{survfit})\cr result of \code{\link[survival:survfit]{survival::survfit()}}.}
 
-\item{armval}{(\code{string}) \cr used as strata name when treatment arm
+\item{armval}{(\code{string})\cr used as strata name when treatment arm
 variable only has one level. Default is "All".}
 
-\item{max_time}{(\code{numeric})\cr maximum value to show on X axis.
-Only data values less than or up to to this threshold value will be plotted.(\code{NULL} for
-default)}
+\item{max_time}{(\code{numeric})\cr maximum value to show on X axis. Only data values less than or up to
+this threshold value will be plotted (defaults to \code{NULL}).}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/h_format_row.Rd
+++ b/man/h_format_row.Rd
@@ -7,15 +7,15 @@
 h_format_row(x, format, labels = NULL)
 }
 \arguments{
-\item{x}{(named \code{list}) \cr list of numerical values to be formatted and optionally labeled.
+\item{x}{(named \code{list})\cr list of numerical values to be formatted and optionally labeled.
 Elements of \code{x} must be \code{numeric} vectors.}
 
-\item{format}{(named \code{character} or \code{NULL}) \cr
+\item{format}{(named \code{character} or \code{NULL})\cr
 format patterns for \code{x}. Names of the \code{format} must match the names of \code{x}.
 This parameter is passed directly to the \code{rtables::format_rcell}
 function through the \code{format} parameter.}
 
-\item{labels}{(named \code{character} or \code{NULL}) \cr
+\item{labels}{(named \code{character} or \code{NULL})\cr
 optional labels for \code{x}. Names of the \code{labels} must match the names of \code{x}.
 When a label is not specified for an element of \code{x},
 then this function tries to use \code{label} or \code{names} (in this order) attribute of that element

--- a/man/h_g_ipp.Rd
+++ b/man/h_g_ipp.Rd
@@ -21,7 +21,7 @@ h_g_ipp(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{xvar}{(\code{string})\cr time point variable to be plotted on x-axis.}
 
@@ -37,7 +37,7 @@ h_g_ipp(
 
 \item{subtitle}{(\code{string})\cr subtitle for plot.}
 
-\item{caption}{(\code{character} scalar) \cr optional caption below the plot.}
+\item{caption}{(\code{character} scalar)\cr optional caption below the plot.}
 
 \item{add_baseline_hline}{(\code{flag})\cr adds horizontal line at baseline y-value on
 plot when TRUE.}

--- a/man/h_ggkm.Rd
+++ b/man/h_ggkm.Rd
@@ -26,14 +26,11 @@ h_ggkm(
 \arguments{
 \item{data}{(\code{data.frame})\cr survival data as pre-processed by \code{h_data_plot}.}
 
-\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr
-numeric vector of ticks or single number with spacing
-between ticks on the x axis.
-If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
+\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr numeric vector of ticks or single number with spacing
+between ticks on the x axis. If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
 an optimal tick position on the x axis.}
 
-\item{yval}{(\code{string})\cr value of y-axis. Should be either
-\code{Survival} (default) or \code{Failure} probability.}
+\item{yval}{(\code{string})\cr value of y-axis. Options are \code{Survival} (default) and \code{Failure} probability.}
 
 \item{censor_show}{(\code{flag})\cr whether to show censored.}
 
@@ -45,9 +42,8 @@ an optimal tick position on the x axis.}
 
 \item{footnotes}{(\code{string})\cr footnotes for plot.}
 
-\item{max_time}{(\code{numeric})\cr maximum value to show on X axis.
-Only data values less than or up to to this threshold value will be plotted.(\code{NULL} for
-default)}
+\item{max_time}{(\code{numeric})\cr maximum value to show on X axis. Only data values less than or up to
+this threshold value will be plotted (defaults to \code{NULL}).}
 
 \item{lwd}{(\code{numeric})\cr line width. Length of a vector should be equal
 to number of strata from \code{\link[survival:survfit]{survival::survfit()}}.}
@@ -64,8 +60,7 @@ to number of strata from \code{\link[survival:survfit]{survival::survfit()}}.}
 
 \item{ci_ribbon}{(\code{flag})\cr draw the confidence interval around the Kaplan-Meier curve.}
 
-\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to
-control outlook of the Kaplan-Meier curve.}
+\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to control outlook of the Kaplan-Meier curve.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/h_glm_count.Rd
+++ b/man/h_glm_count.Rd
@@ -19,30 +19,30 @@ h_ppmeans(obj, .df_row, arm, conf_level)
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.df_row}{(\verb{data frame})\cr data set that includes all the variables that are called
+\item{.df_row}{(\code{data.frame})\cr data set that includes all the variables that are called
 in \code{.var} and \code{variables}.}
 
 \item{variables}{(named \code{list} of \code{strings})\cr list of additional analysis variables, with
 expected elements:
 \itemize{
-\item \code{arm}: (\code{string})\cr group variable, for which the covariate adjusted means of multiple
+\item \code{arm} (\code{string})\cr group variable, for which the covariate adjusted means of multiple
 groups will be summarized. Specifically, the first level of \code{arm} variable is taken as the
 reference group.
-\item \code{covariates}: (\code{character})\cr a vector that can contain single variable names (such as
+\item \code{covariates} (\code{character})\cr a vector that can contain single variable names (such as
 \code{"X1"}), and/or interaction terms indicated by \code{"X1 * X2"}.
-\item \code{offset}: (\code{numeric})\cr a numeric vector or scalar adding an offset.
+\item \code{offset} (\code{numeric})\cr a numeric vector or scalar adding an offset.
 }}
 
-\item{obj}{(\code{glm.fit}) fitted model object used to derive the mean rate estimates in each treatment arm.}
+\item{obj}{(\code{glm.fit})\cr fitted model object used to derive the mean rate estimates in each treatment arm.}
 
-\item{conf_level}{(\code{numeric}) value used to derive the confidence interval for the rate.}
+\item{conf_level}{(\code{numeric})\cr value used to derive the confidence interval for the rate.}
 
 \item{`weights`(`character`)\cr}{character vector specifying weights used in averaging predictions.}
 
 \item{`distribution`(`character`)\cr}{a character value specifying the distribution
 used in the regression (poisson, quasipoisson).}
 
-\item{`arm`:}{(\code{string})\cr group variable, for which the covariate adjusted means of multiple
+\item{`arm`}{(\code{string})\cr group variable, for which the covariate adjusted means of multiple
 groups will be summarized. Specifically, the first level of \code{arm} variable is taken as the
 reference group.}
 }
@@ -64,7 +64,6 @@ selected model (poisson, quasipoisson, negative binomial).
 
 }}
 \examples{
-
 # Internal function - h_glm_poisson
 \dontrun{
 h_glm_poisson(
@@ -84,7 +83,6 @@ h_glm_quasipoisson(
 )
 }
 
-
 # Internal function - h_glm_count
 \dontrun{
 h_glm_count(
@@ -94,7 +92,6 @@ h_glm_count(
   distribution = "poisson"
 )
 }
-
 
 # Internal function - h_ppmeans
 \dontrun{

--- a/man/h_grob_median_surv.Rd
+++ b/man/h_grob_median_surv.Rd
@@ -15,7 +15,7 @@ h_grob_median_surv(
 \arguments{
 \item{fit_km}{(\code{survfit})\cr result of \code{\link[survival:survfit]{survival::survfit()}}.}
 
-\item{armval}{(\code{string}) \cr used as strata name when treatment arm
+\item{armval}{(\code{string})\cr used as strata name when treatment arm
 variable only has one level. Default is "All".}
 
 \item{x}{a \code{numeric} value between 0 and 1 specifying x-location.}

--- a/man/h_incidence_rate.Rd
+++ b/man/h_incidence_rate.Rd
@@ -19,21 +19,21 @@ h_incidence_rate_byar(person_years, n_events, alpha = 0.05)
 h_incidence_rate(person_years, n_events, control = control_incidence_rate())
 }
 \arguments{
-\item{person_years}{(\code{numeric}) \cr total person-years at risk.}
+\item{person_years}{(\code{numeric})\cr total person-years at risk.}
 
-\item{n_events}{(\code{integer}) \cr number of events observed.}
+\item{n_events}{(\code{integer})\cr number of events observed.}
 
-\item{alpha}{(\code{numeric}) \cr two-sided alpha-level for confidence interval.}
+\item{alpha}{(\code{numeric})\cr two-sided alpha-level for confidence interval.}
 
-\item{control}{(\code{list}) \cr parameters for estimation details, specified by using
-the helper function \code{\link[=control_incidence_rate]{control_incidence_rate()}}. Possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for estimation details, specified by using
+the helper function \code{\link[=control_incidence_rate]{control_incidence_rate()}}. Possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion}) \cr confidence level for the estimated incidence rate.
-\item \code{conf_type}: (\code{string}) \cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
+\item \code{conf_level}: (\code{proportion})\cr confidence level for the estimated incidence rate.
+\item \code{conf_type}: (\code{string})\cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
 for confidence interval type.
-\item \code{time_unit_input}: (\code{string}) \cr \code{day}, \code{week}, \code{month}, or \code{year} (default)
+\item \code{time_unit_input}: (\code{string})\cr \code{day}, \code{week}, \code{month}, or \code{year} (default)
 indicating time unit for data input.
-\item \code{time_unit_output}: (\code{numeric}) \cr time unit for desired output (in person-years).
+\item \code{time_unit_output}: (\code{numeric})\cr time unit for desired output (in person-years).
 }}
 }
 \description{

--- a/man/h_map_for_count_abnormal.Rd
+++ b/man/h_map_for_count_abnormal.Rd
@@ -14,11 +14,11 @@ h_map_for_count_abnormal(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 
-\item{abnormal}{(\verb{named list})\cr identifying the abnormal range level(s) in \code{df}. Based on the levels of abnormality
+\item{abnormal}{(named \code{list})\cr identifying the abnormal range level(s) in \code{df}. Based on the levels of abnormality
 of the input dataset, it can be something like \code{list(Low = "LOW LOW", High = "HIGH HIGH")} or
 \verb{abnormal = list(Low = "LOW", High = "HIGH"))}}
 

--- a/man/h_odds_ratio.Rd
+++ b/man/h_odds_ratio.Rd
@@ -11,8 +11,8 @@ or_glm(data, conf_level)
 or_clogit(data, conf_level)
 }
 \arguments{
-\item{data}{(\verb{data frame})\cr
-with at least the variables \code{rsp}, \code{grp}, and in addition \code{strata} for \code{\link[=or_clogit]{or_clogit()}}.}
+\item{data}{(\code{data.frame})\cr data frame containing at least the variables \code{rsp} and \code{grp}, and optionally
+\code{strata} for \code{\link[=or_clogit]{or_clogit()}}.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 }

--- a/man/h_prop_diff.Rd
+++ b/man/h_prop_diff.Rd
@@ -29,22 +29,18 @@ prop_diff_strat_nc(
 \arguments{
 \item{rsp}{(\code{logical})\cr whether each subject is a responder or not.}
 
-\item{grp}{(\code{factor})\cr
-vector assigning observations to one out of two groups
+\item{grp}{(\code{factor})\cr vector assigning observations to one out of two groups
 (e.g. reference and treatment group).}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{correct}{\code{logical}\cr
-include the continuity correction. For further information, see for example
-\code{\link[stats:prop.test]{stats::prop.test()}}.}
+\item{correct}{\code{logical}\cr include the continuity correction. For further
+information, see \code{\link[stats:prop.test]{stats::prop.test()}}.}
 
-\item{strata}{(\code{factor})\cr
-with one level per stratum and same length as \code{rsp}.}
+\item{strata}{(\code{factor})\cr variable with one level per stratum and same length as \code{rsp}.}
 
-\item{weights_method}{(\code{string}) \cr
-it can be one of \code{c("cmh", "heuristic")} and directs the way weights are
-estimated.}
+\item{weights_method}{(\code{string})\cr weights method. Can be either \code{"cmh"} or \code{"heuristic"}
+and directs the way weights are estimated.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/h_prop_diff_test.Rd
+++ b/man/h_prop_diff_test.Rd
@@ -17,13 +17,11 @@ prop_schouten(tbl)
 prop_fisher(tbl)
 }
 \arguments{
-\item{tbl}{(\code{matrix})\cr
-with two groups in rows and the binary response (\code{TRUE}/\code{FALSE}) in
-columns.}
+\item{tbl}{(\code{matrix})\cr matrix with two groups in rows and the binary response
+(\code{TRUE}/\code{FALSE}) in columns.}
 
-\item{ary}{(\code{array}, 3 dimensions)\cr
-with two groups in rows, the binary response (\code{TRUE}/\code{FALSE}) in
-columns, the strata in the third dimension.}
+\item{ary}{(\code{array}, 3 dimensions)\cr array with two groups in rows, the binary response
+(\code{TRUE}/\code{FALSE}) in columns, and the strata in the third dimension.}
 }
 \description{
 Helper functions to implement various tests on the difference between two

--- a/man/h_proportions.Rd
+++ b/man/h_proportions.Rd
@@ -36,17 +36,13 @@ prop_jeffreys(rsp, conf_level)
 
 \item{correct}{(\code{flag})\cr apply continuity correction.}
 
-\item{strata}{(\code{factor})\cr
-with one level per stratum and same length as \code{rsp}.}
+\item{strata}{(\code{factor})\cr variable with one level per stratum and same length as \code{rsp}.}
 
-\item{weights}{(\code{numeric} or \code{NULL}) \cr
-weights for each level of the strata. If \code{NULL}, they are
-estimated using the iterative algorithm proposed in
-\insertCite{Yan2010-jt;textual}{tern} that minimizes the weighted squared
-length of the confidence interval.}
+\item{weights}{(\code{numeric} or \code{NULL})\cr weights for each level of the strata. If \code{NULL}, they are
+estimated using the iterative algorithm proposed in \insertCite{Yan2010-jt;textual}{tern} that
+minimizes the weighted squared length of the confidence interval.}
 
-\item{max_iterations}{(\code{count}) \cr
-maximum number of iterations for the iterative procedure used
+\item{max_iterations}{(\code{count})\cr maximum number of iterations for the iterative procedure used
 to find estimates of optimal weights.}
 }
 \description{

--- a/man/h_response_subgroups.Rd
+++ b/man/h_response_subgroups.Rd
@@ -43,15 +43,12 @@ levels that belong to it in the character vectors that are elements of the list.
 
 \item{label_all}{(\code{string})\cr label for the total population analysis.}
 
-\item{strata_data}{(\code{factor}, \code{data.frame} or \code{NULL})\cr
-required if stratified analysis is performed.}
+\item{strata_data}{(\code{factor}, \code{data.frame} or \code{NULL})\cr required if stratified analysis is performed.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string})\cr
-specifies the test used to calculate the p-value for the difference between
-two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL}
-so no test is performed.}
+\item{method}{(\code{string})\cr specifies the test used to calculate the p-value for the difference between
+two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL} so no test is performed.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/h_split_by_subgroups.Rd
+++ b/man/h_split_by_subgroups.Rd
@@ -7,7 +7,7 @@
 h_split_by_subgroups(data, subgroups, groups_lists = list())
 }
 \arguments{
-\item{data}{(\verb{data frame})\cr dataset to split.}
+\item{data}{(\code{data.frame})\cr dataset to split.}
 
 \item{subgroups}{(\code{character})\cr names of factor variables from \code{data} used to create subsets.
 Unused levels not present in \code{data} are dropped. Note that the order in this vector

--- a/man/h_stack_by_baskets.Rd
+++ b/man/h_stack_by_baskets.Rd
@@ -15,7 +15,7 @@ h_stack_by_baskets(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{baskets}{(\code{character})\cr variable names of the selected Standardized/Customized queries.}
 
@@ -24,7 +24,7 @@ h_stack_by_baskets(
 \item{keys}{(\code{character})\cr names of the key variables to be returned
 along with the new variable created.}
 
-\item{aag_summary}{(\verb{data frame})\cr containing the \code{SMQ} baskets
+\item{aag_summary}{(\code{data.frame})\cr containing the \code{SMQ} baskets
 and the levels of interest for the final \code{SMQ} variable. This is useful when
 there are some levels of interest that are not observed in the \code{df} dataset.
 The two columns of this dataset should be named \code{basket} and \code{basket_name}.}

--- a/man/h_step.Rd
+++ b/man/h_step.Rd
@@ -37,9 +37,9 @@ h_step_rsp_est(
 )
 }
 \arguments{
-\item{x}{(\code{numeric}) biomarker value(s) to use (without \code{NA}).}
+\item{x}{(\code{numeric})\cr biomarker value(s) to use (without \code{NA}).}
 
-\item{control}{(named \code{list}) from \code{control_step()}.}
+\item{control}{(named \code{list})\cr output from \code{control_step()}.}
 
 \item{data}{(\code{data.frame})\cr the dataset containing the variables to summarize.}
 

--- a/man/h_survival_biomarkers_subgroups.Rd
+++ b/man/h_survival_biomarkers_subgroups.Rd
@@ -28,15 +28,16 @@ returned by \code{\link[=extract_survival_biomarkers]{extract_survival_biomarker
 added by that high-level function relative to what is returned by \code{\link[=h_coxreg_mult_cont_df]{h_coxreg_mult_cont_df()}},
 see the example).}
 
-\item{vars}{(\code{character})\cr the name of statistics to be reported among
-\code{n_tot_events} (total number of events per group),
-\code{n_tot} (total number of observations per group),
-\code{median} (median survival time),
-\code{hr} (hazard ratio),
-\code{ci} (confidence interval of hazard ratio) and
-\code{pval} (p value of the effect).
-Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as both \code{hr} and \code{ci}
-are required.}
+\item{vars}{(\code{character})\cr the names of statistics to be reported among:
+\itemize{
+\item \code{n_tot_events}: total number of events per group.
+\item \code{n_tot}: total number of observations per group.
+\item \code{median}: median survival time.
+\item \code{hr}: hazard ratio.
+\item \code{ci}: confidence interval of hazard ratio.
+\item \code{pval}: p-value of the effect.
+Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as both \code{hr} and \code{ci} are required.
+}}
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips
 displaying unit.}

--- a/man/h_survival_duration_subgroups.Rd
+++ b/man/h_survival_duration_subgroups.Rd
@@ -44,18 +44,16 @@ levels that belong to it in the character vectors that are elements of the list.
 
 \item{label_all}{(\code{string})\cr label for the total population analysis.}
 
-\item{strata_data}{(\code{factor}, \code{data.frame} or \code{NULL})\cr
-required if stratified analysis is performed.}
+\item{strata_data}{(\code{factor}, \code{data.frame} or \code{NULL})\cr required if stratified analysis is performed.}
 
-\item{control}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for comparison details, specified by using the helper function
+\code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
-Default method is "log-rank" which comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood"
-that comes from \code{\link[survival:coxph]{survival::coxph()}}.
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1. Default method is "log-rank" which
+comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood" (from \code{\link[survival:coxph]{survival::coxph()}}).
+\item \code{ties} (\code{string})\cr specifying the method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 }
 \description{

--- a/man/h_tbl_coxph_pairwise.Rd
+++ b/man/h_tbl_coxph_pairwise.Rd
@@ -7,24 +7,24 @@
 h_tbl_coxph_pairwise(df, variables, control_coxph_pw = control_coxph())
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{variables}{(named \code{list}) of variable names. Details are: \cr
+\item{variables}{(named \code{list})\cr variable names. Details are:
 \itemize{
-\item \code{tte}: variable indicating time-to-event duration values (\code{numeric}).
-\item \code{is_event}: event variable (\code{logical}) \cr \code{TRUE} if event, \code{FALSE} if time to event is censored.
-\item \code{arm}: the treatment group variable (\code{factor}).
-\item \code{strat}: (\code{character} or \code{NULL}) variable names indicating stratification factors.
+\item \code{tte} (\code{numeric})\cr variable indicating time-to-event duration values.
+\item \code{is_event} (\code{logical})\cr event variable. \code{TRUE} if event, \code{FALSE} if time to event is censored.
+\item \code{arm} (\code{factor})\cr the treatment group variable.
+\item \code{strat} (\code{character} or \code{NULL})\cr variable names indicating stratification factors.
 }}
 
-\item{control_coxph_pw}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control_coxph_pw}{(\code{list})\cr parameters for comparison details, specified by using
+the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1.
 Default method is "log-rank", can also be set to "wald" or "likelihood".
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{ties} (\code{string})\cr method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 }
 \description{

--- a/man/h_tbl_median_surv.Rd
+++ b/man/h_tbl_median_surv.Rd
@@ -9,7 +9,7 @@ h_tbl_median_surv(fit_km, armval = "All")
 \arguments{
 \item{fit_km}{(\code{survfit})\cr result of \code{\link[survival:survfit]{survival::survfit()}}.}
 
-\item{armval}{(\code{string}) \cr used as strata name when treatment arm
+\item{armval}{(\code{string})\cr used as strata name when treatment arm
 variable only has one level. Default is "All".}
 }
 \description{

--- a/man/h_worsen_counter.Rd
+++ b/man/h_worsen_counter.Rd
@@ -7,17 +7,16 @@
 h_worsen_counter(df, id, .var, baseline_var, direction_var)
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{baseline_var}{(\code{string}) \cr baseline lab grade variable}
+\item{baseline_var}{(\code{string})\cr baseline lab grade variable}
 
-\item{direction_var}{(\code{string}) \cr
-Direction variable specifying the direction of the shift table of interest.
+\item{direction_var}{(\code{string})\cr Direction variable specifying the direction of the shift table of interest.
 Only lab records flagged by \code{L}, \code{H} or \code{B} are included in the shift table.
 \itemize{
 \item \code{L}: low direction only

--- a/man/h_xticks.Rd
+++ b/man/h_xticks.Rd
@@ -9,15 +9,12 @@ h_xticks(data, xticks = NULL, max_time = NULL)
 \arguments{
 \item{data}{(\code{data.frame})\cr survival data as pre-processed by \code{h_data_plot}.}
 
-\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr
-numeric vector of ticks or single number with spacing
-between ticks on the x axis.
-If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
+\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr numeric vector of ticks or single number with spacing
+between ticks on the x axis. If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
 an optimal tick position on the x axis.}
 
-\item{max_time}{(\code{numeric})\cr maximum value to show on X axis.
-Only data values less than or up to to this threshold value will be plotted.(\code{NULL} for
-default)}
+\item{max_time}{(\code{numeric})\cr maximum value to show on X axis. Only data values less than or up to
+this threshold value will be plotted (defaults to \code{NULL}).}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/incidence_rate.Rd
+++ b/man/incidence_rate.Rd
@@ -36,24 +36,24 @@ estimate_incidence_rate(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{n_events}{(\code{integer}) \cr number of events observed.}
+\item{n_events}{(\code{integer})\cr number of events observed.}
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{control}{(\code{list}) \cr parameters for estimation details, specified by using
-the helper function \code{\link[=control_incidence_rate]{control_incidence_rate()}}. Possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for estimation details, specified by using
+the helper function \code{\link[=control_incidence_rate]{control_incidence_rate()}}. Possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion}) \cr confidence level for the estimated incidence rate.
-\item \code{conf_type}: (\code{string}) \cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
+\item \code{conf_level} (\code{proportion})\cr confidence level for the estimated incidence rate.
+\item \code{conf_type} (\code{string})\cr \code{normal} (default), \code{normal_log}, \code{exact}, or \code{byar}
 for confidence interval type.
-\item \code{time_unit_input}: (\code{string}) \cr \code{day}, \code{week}, \code{month}, or \code{year} (default)
+\item \code{time_unit_input} (\code{string})\cr \code{day}, \code{week}, \code{month}, or \code{year} (default)
 indicating time unit for data input.
-\item \code{time_unit_output}: (\code{numeric}) \cr time unit for desired output (in person-years).
+\item \code{time_unit_output} (\code{numeric})\cr time unit for desired output (in person-years).
 }}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -75,17 +75,17 @@ to avoid warnings from \code{rtables}.}
 
 \item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 
-\item{person_years}{(\code{numeric}) \cr total person-years at risk.}
+\item{person_years}{(\code{numeric})\cr total person-years at risk.}
 
-\item{alpha}{(\code{numeric}) \cr two-sided alpha-level for confidence interval.}
+\item{alpha}{(\code{numeric})\cr two-sided alpha-level for confidence interval.}
 }
 \value{
 The statistics are:
-\itemize{
-\item \code{person_years}: total person-years at risk
-\item \code{n_events}: total number of events observed
-\item \code{rate}: estimated incidence rate
-\item \code{rate_ci}: confidence interval for the incidence rate
+\describe{
+\item{person_years}{total person-years at risk}
+\item{n_events}{total number of events observed}
+\item{rate}{estimated incidence rate}
+\item{rate_ci}{confidence interval for the incidence rate}
 }
 }
 \description{
@@ -107,7 +107,6 @@ function \code{s_incidence_rate} and desired format.
 
 }}
 \examples{
-
 library(dplyr)
 
 df <- data.frame(

--- a/man/individual_patient_plot.Rd
+++ b/man/individual_patient_plot.Rd
@@ -24,7 +24,7 @@ g_ipp(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{xvar}{(\code{string})\cr time point variable to be plotted on x-axis.}
 
@@ -40,7 +40,7 @@ g_ipp(
 
 \item{subtitle}{(\code{string})\cr subtitle for plot.}
 
-\item{caption}{(\code{character} scalar) \cr optional caption below the plot.}
+\item{caption}{(\code{character} scalar)\cr optional caption below the plot.}
 
 \item{add_baseline_hline}{(\code{flag})\cr adds horizontal line at baseline y-value on
 plot when TRUE.}

--- a/man/kaplan_meier.Rd
+++ b/man/kaplan_meier.Rd
@@ -4,34 +4,31 @@
 \alias{kaplan_meier}
 \title{Kaplan-Meier Plot}
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{variables}{(named \code{list}) of variable names. Details are: \cr
+\item{variables}{(named \code{list})\cr variable names. Details are:
 \itemize{
-\item \code{tte}: variable indicating time-to-event duration values (\code{numeric}).
-\item \code{is_event}: event variable (\code{logical}) \cr \code{TRUE} if event, \code{FALSE} if time to event is censored.
-\item \code{arm}: the treatment group variable (\code{factor}).
-\item \code{strat}: (\code{character} or \code{NULL}) variable names indicating stratification factors.
+\item \code{tte} (\code{numeric})\cr variable indicating time-to-event duration values.
+\item \code{is_event} (\code{logical})\cr event variable. \code{TRUE} if event, \code{FALSE} if time to event is censored.
+\item \code{arm} (\code{factor})\cr the treatment group variable.
+\item \code{strat} (\code{character} or \code{NULL})\cr variable names indicating stratification factors.
 }}
 
-\item{control_surv}{a (\code{list}) of parameters for comparison details, specified by using \cr
-the helper function \code{\link{control_surv_timepoint}}. Some possible parameter options are: \cr
+\item{control_surv}{(\code{list})\cr parameters for comparison details, specified by using
+the helper function \code{\link{control_surv_timepoint}}. Some possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for survival rate.
-\item \code{conf_type}: (\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for survival rate.
+\item \code{conf_type} (\code{string})\cr "plain" (default), "log", "log-log" for confidence interval type,
 see more in \code{\link[survival:survfit]{survival::survfit()}}. Note that the option "none" is no longer supported.
 }}
 
 \item{data}{(\code{data.frame})\cr survival data as pre-processed by \code{h_data_plot}.}
 
-\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr
-numeric vector of ticks or single number with spacing
-between ticks on the x axis.
-If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
+\item{xticks}{(\code{numeric}, \code{number}, or \code{NULL})\cr numeric vector of ticks or single number with spacing
+between ticks on the x axis. If \code{NULL} (default), \code{\link[labeling:extended]{labeling::extended()}} is used to determine
 an optimal tick position on the x axis.}
 
-\item{yval}{(\code{string})\cr value of y-axis. Should be either
-\code{Survival} (default) or \code{Failure} probability.}
+\item{yval}{(\code{string})\cr value of y-axis. Options are \code{Survival} (default) and \code{Failure} probability.}
 
 \item{censor_show}{(\code{flag})\cr whether to show censored.}
 
@@ -56,23 +53,20 @@ to number of strata from \code{\link[survival:survfit]{survival::survfit()}}.}
 
 \item{size}{(\code{numeric})\cr size of censored point, a class of \code{unit}.}
 
-\item{max_time}{(\code{numeric})\cr maximum value to show on X axis.
-Only data values less than or up to to this threshold value will be plotted.(\code{NULL} for
-default)}
+\item{max_time}{(\code{numeric})\cr maximum value to show on X axis. Only data values less than or up to
+this threshold value will be plotted (defaults to \code{NULL}).}
 
-\item{font_size}{(\code{number}) \cr font size to be used.}
+\item{font_size}{(\code{number})\cr font size to be used.}
 
 \item{ci_ribbon}{(\code{flag})\cr draw the confidence interval around the Kaplan-Meier curve.}
 
-\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to
-control outlook of the Kaplan-Meier curve.}
+\item{ggtheme}{(\code{theme})\cr a graphical theme as provided by \code{ggplot2} to control outlook of the Kaplan-Meier curve.}
 
-\item{annot_at_risk}{(\code{flag})\cr compute and add the annotation table
-reporting the number of patient at risk matching the main grid of the
-Kaplan-Meier curve.}
+\item{annot_at_risk}{(\code{flag})\cr compute and add the annotation table reporting the number of patient at risk
+matching the main grid of the Kaplan-Meier curve.}
 
-\item{annot_surv_med}{(\code{flag})\cr compute and add the annotation table
-on the Kaplan-Meier curve estimating the median survival time per group.}
+\item{annot_surv_med}{(\code{flag})\cr compute and add the annotation table on the Kaplan-Meier curve estimating the
+median survival time per group.}
 
 \item{annot_coxph}{(\code{flag})\cr add the annotation table from a \code{\link[survival:coxph]{survival::coxph()}} model.}
 
@@ -82,20 +76,20 @@ on the Kaplan-Meier curve estimating the median survival time per group.}
 \item{annot_stats_vlines}{(\code{flag})\cr add vertical lines corresponding to each of the statistics
 specified by \code{annot_stats}. If \code{annot_stats} is \code{NULL} no lines will be added.}
 
-\item{control_coxph_pw}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control_coxph_pw}{(\code{list})\cr parameters for comparison details, specified by using
+the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1.
 Default method is "log-rank", can also be set to "wald" or "likelihood".
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{ties} (\code{string})\cr method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 
-\item{position_coxph}{\code{numeric} \cr x and y positions for plotting \code{\link[survival:coxph]{survival::coxph()}} model.}
+\item{position_coxph}{(\code{numeric})\cr x and y positions for plotting \code{\link[survival:coxph]{survival::coxph()}} model.}
 
-\item{position_surv_med}{\code{numeric} \cr x and y positions for plotting annotation table
-estimating median survival time per group}
+\item{position_surv_med}{(\code{numeric})\cr x and y positions for plotting annotation table estimating median survival
+time per group.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/n_available.Rd
+++ b/man/n_available.Rd
@@ -7,7 +7,7 @@
 n_available(x)
 }
 \arguments{
-\item{x}{(\code{vector})\cr where to count the non-missing values.}
+\item{x}{(\code{any})\cr vector in which to count non-missing values.}
 }
 \value{
 Number of non-missing values.

--- a/man/odds_ratio.Rd
+++ b/man/odds_ratio.Rd
@@ -42,16 +42,16 @@ estimate_odds_ratio(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
-\item{.df_row}{(\verb{data frame})\cr data frame across all of the columns for the given row split.}
+\item{.df_row}{(\code{data.frame})\cr data frame across all of the columns for the given row split.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 

--- a/man/pairwise.Rd
+++ b/man/pairwise.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/coxph.R
 \name{pairwise}
 \alias{pairwise}
-\title{Pairwise formula special term}
+\title{Pairwise Formula Special Term}
 \usage{
 pairwise(x)
 }
@@ -17,9 +17,9 @@ every tested level in comparison to the reference level.
 }
 \details{
 Let's \code{ARM} being a factor with level A, B, C; let's be B the reference level,
-a model calling the formula including \code{pairwise(ARM)} will result in two models
+a model calling the formula including \code{pairwise(ARM)} will result in two models:
 \itemize{
-\item a model including only levels A and B, and effect of A estimated in reference to B.
-\item a model including only levels C and B, the effect of C estimated in reference to B.
+\item A model including only levels A and B, and effect of A estimated in reference to B.
+\item A model including only levels C and B, the effect of C estimated in reference to B.
 }
 }

--- a/man/prop_diff.Rd
+++ b/man/prop_diff.Rd
@@ -45,12 +45,12 @@ estimate_proportion_diff(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -58,12 +58,10 @@ by a statistics function.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{method}{(\code{string})\cr
-the method used for the confidence interval estimation.}
+\item{method}{(\code{string})\cr the method used for the confidence interval estimation.}
 
-\item{weights_method}{(\code{string}) \cr
-it can be one of \code{c("cmh", "heuristic")} and directs the way weights are
-estimated.}
+\item{weights_method}{(\code{string})\cr weights method. Can be either \code{"cmh"} or \code{"heuristic"}
+and directs the way weights are estimated.}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 

--- a/man/prop_diff_test.Rd
+++ b/man/prop_diff_test.Rd
@@ -38,19 +38,18 @@ test_proportion_diff(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 
-\item{method}{(\code{string})\cr
-one of (\code{chisq}, \code{cmh}, \code{fisher}, \code{schouten}; specifies the test used
+\item{method}{(\code{string})\cr one of \code{chisq}, \code{cmh}, \code{fisher}, or \code{schouten}; specifies the test used
 to calculate the p-value.}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -72,9 +71,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 
-\item{tbl}{(\code{matrix})\cr
-with two groups in rows and the binary response (\code{TRUE}/\code{FALSE}) in
-columns.}
+\item{tbl}{(\code{matrix})\cr matrix with two groups in rows and the binary response
+(\code{TRUE}/\code{FALSE}) in columns.}
 }
 \value{
 Named \code{list} with a single item \code{pval} with an attribute \code{label}

--- a/man/reapply_varlabels.Rd
+++ b/man/reapply_varlabels.Rd
@@ -9,7 +9,7 @@ reapply_varlabels(x, varlabels, ...)
 \arguments{
 \item{x}{(\code{vector})\cr vector of elements that needs new labels.}
 
-\item{varlabels}{(\code{vector})\cr labels for \code{x}.}
+\item{varlabels}{(\code{character})\cr vector of labels for \code{x}.}
 
 \item{...}{further parameters to be added to the list.}
 }

--- a/man/response_subgroups.Rd
+++ b/man/response_subgroups.Rd
@@ -32,7 +32,7 @@ created using \code{\link[=extract_rsp_subgroups]{extract_rsp_subgroups()}}.}
 \code{pval} (p value of the effect).
 Note, the statistics \code{n_tot}, \code{or} and \code{ci} are required.}
 
-\item{data}{(\verb{data frame})\cr the dataset containing the variables to summarize.}
+\item{data}{(\code{data.frame})\cr the dataset containing the variables to summarize.}
 
 \item{groups_lists}{(named \code{list} of \code{list})\cr optionally contains for each \code{subgroups} variable a
 list, which specifies the new group levels via the names and the
@@ -40,10 +40,8 @@ levels that belong to it in the character vectors that are elements of the list.
 
 \item{label_all}{(\code{string})\cr label for the total population analysis.}
 
-\item{method}{(\code{string})\cr
-specifies the test used to calculate the p-value for the difference between
-two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL}
-so no test is performed.}
+\item{method}{(\code{string})\cr specifies the test used to calculate the p-value for the difference between
+two proportions. For options, see \code{\link[=s_test_proportion_diff]{s_test_proportion_diff()}}. Default is \code{NULL} so no test is performed.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}

--- a/man/s_cox_multivariate.Rd
+++ b/man/s_cox_multivariate.Rd
@@ -13,20 +13,18 @@ s_cox_multivariate(
 )
 }
 \arguments{
-\item{formula}{A \code{formula} corresponding to the investigated \code{\link[survival:Surv]{survival model}}
+\item{formula}{(\code{formula})\cr A formula corresponding to the investigated \code{\link[survival:Surv]{survival::Surv()}} survival model
 including covariates.}
 
-\item{data}{A \code{data.frame} which includes the variable in formula and covariates.}
+\item{data}{(\code{data.frame})\cr A data frame which includes the variable in formula and covariates.}
 
-\item{conf_level}{The level of confidence for the hazard ration interval estimations. Default is 0.95.}
+\item{conf_level}{(\code{proportion})\cr The confidence level for the hazard ratio interval estimations. Default is 0.95.}
 
-\item{pval_method}{The method used for the estimation of p.values, should be one of \code{"wald"} (default) or
-\code{"likelihood"}.}
+\item{pval_method}{(\code{character})\cr The method used for the estimation of p-values, should be one of
+"wald" (default) or "likelihood".}
 
-\item{...}{Optional parameters passed to \code{\link[survival:coxph]{coxph()}}
-\itemize{
-\item \code{ties} a character string specifying the method for tie handling, one of \code{exact} (default), \code{efron}, \code{breslow}.
-}}
+\item{...}{Optional parameters passed to \code{\link[survival:coxph]{survival::coxph()}}. Can include \code{ties}, a character string specifying the
+method for tie handling, one of \code{exact} (default), \code{efron}, \code{breslow}.}
 }
 \description{
 Analyses based on multivariate Cox model are usually not performed for the Controlled Substance Reporting or

--- a/man/split_cols_by_groups.Rd
+++ b/man/split_cols_by_groups.Rd
@@ -15,7 +15,7 @@ by a statistics function.}
 \item{groups_list}{(named \code{list} of \code{character})\cr specifies the new group levels via the names and the
 levels that belong to it in the character vectors that are elements of the list.}
 
-\item{ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{...}{additional arguments, see \emph{note} section.}
 }

--- a/man/strata_normal_quantile.Rd
+++ b/man/strata_normal_quantile.Rd
@@ -9,11 +9,9 @@ strata_normal_quantile(vars, weights, conf_level)
 \arguments{
 \item{vars}{(\code{character})\cr variable names for the primary analysis variable to be iterated over.}
 
-\item{weights}{(\code{numeric} or \code{NULL}) \cr
-weights for each level of the strata. If \code{NULL}, they are
-estimated using the iterative algorithm proposed in
-\insertCite{Yan2010-jt;textual}{tern} that minimizes the weighted squared
-length of the confidence interval.}
+\item{weights}{(\code{numeric} or \code{NULL})\cr weights for each level of the strata. If \code{NULL}, they are
+estimated using the iterative algorithm proposed in \insertCite{Yan2010-jt;textual}{tern} that
+minimizes the weighted squared length of the confidence interval.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 }

--- a/man/summarize_ancova.Rd
+++ b/man/summarize_ancova.Rd
@@ -46,16 +46,16 @@ summarize_ancova(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.df_row}{(\verb{data frame})\cr data frame across all of the columns for the given row split.}
+\item{.df_row}{(\code{data.frame})\cr data frame across all of the columns for the given row split.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -66,7 +66,7 @@ which will be used to select the specific ANCOVA results. if the interaction is 
 needed, the default option is FALSE}
 
 \item{interaction_item}{(\code{character})\cr name of the variable that should have interactions
-with arm. if the interaction is not needed, the default option is NULL}
+with arm. if the interaction is not needed, the default option is NULL.}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 
@@ -91,14 +91,16 @@ to avoid warnings from \code{rtables}.}
 }
 \value{
 A named list of 5 statistics:
-\itemize{
-\item \code{n}: count of complete sample size for the group.
-\item \code{lsmean}: estimated marginal means in the group.
-\item \code{lsmean_diff}: difference in estimated marginal means in comparison to the reference
-group. If working with the reference group, this will be empty.
-\item \code{lsmean_diff_ci}: confidence level for difference in estimated marginal means in
-comparison to the reference group.
-\item \code{pval}: p-value (not adjusted for multiple comparisons).
+\describe{
+\item{n}{count of complete sample size for the group.}
+\item{lsmean}{estimated marginal means in the group.}
+\item{lsmean_diff}{difference in estimated marginal means in comparison to the reference group.
+If working with the reference group, this will be empty.
+}
+\item{lsmean_diff_ci}{confidence level for difference in estimated marginal means in comparison to the
+reference group.
+}
+\item{pval}{p-value (not adjusted for multiple comparisons).}
 }
 }
 \description{

--- a/man/summarize_change.Rd
+++ b/man/summarize_change.Rd
@@ -22,7 +22,7 @@ summarize_change(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}

--- a/man/summarize_glm_count.Rd
+++ b/man/summarize_glm_count.Rd
@@ -48,16 +48,16 @@ summarize_glm_count(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{.df_row}{(\verb{data frame})\cr data frame across all of the columns for the given row split.}
+\item{.df_row}{(\code{data.frame})\cr data frame across all of the columns for the given row split.}
 
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -86,13 +86,13 @@ to avoid warnings from \code{rtables}.}
 }
 \value{
 A named list of 5 statistics:
-\itemize{
-\item \code{n}: count of complete sample size for the group.
-\item \code{rate}: estimated event rate per follow-up time.
-\item \code{rate_ci}: confidence level for estimated rate per follow-up time.
-\item \code{rate_ratio}: Ratio of event rates in each treatment arm to the reference arm.
-\item \code{rate_ratio_ci}: confidence level for the rate ratio.
-\item \code{pval}: p-value.
+\describe{
+\item{n}{count of complete sample size for the group.}
+\item{rate}{estimated event rate per follow-up time.}
+\item{rate_ci}{confidence level for estimated rate per follow-up time.}
+\item{rate_ratio}{ratio of event rates in each treatment arm to the reference arm.}
+\item{rate_ratio_ci}{confidence level for the rate ratio.}
+\item{pval}{p-value.}
 }
 }
 \description{
@@ -114,7 +114,6 @@ summary tables for analysis of count data using generalized linear models (poiss
 
 }}
 \examples{
-
 # Internal function - s_change_from_baseline
 \dontrun{
 s_glm_count(

--- a/man/summarize_num_patients.Rd
+++ b/man/summarize_num_patients.Rd
@@ -49,7 +49,7 @@ analyze_num_patients(
 )
 }
 \arguments{
-\item{x}{(\code{character} or \code{factor}) \cr vector of patient IDs.}
+\item{x}{(\code{character} or \code{factor})\cr vector of patient IDs.}
 
 \item{labelstr}{(\code{character})\cr label of the level of the parent split currently being summarized
 (must be present as second argument in Content Row Functions).}
@@ -57,18 +57,18 @@ analyze_num_patients(
 \item{.N_col}{(\code{count})\cr row-wise N (row group count) for the group of observations being analyzed
 (i.e. with no column-based subsetting) that is passed by \code{rtables}.}
 
-\item{count_by}{(\code{character} or \code{factor}) \cr optional vector to be combined with \code{x} when counting
+\item{count_by}{(\code{character} or \code{factor})\cr optional vector to be combined with \code{x} when counting
 \code{nonunique} records.}
 
-\item{unique_count_suffix}{(\code{logical}) \cr should \code{"(n)"} suffix be added to \code{unique_count} labels.
+\item{unique_count_suffix}{(\code{logical})\cr should \code{"(n)"} suffix be added to \code{unique_count} labels.
 Defaults to \code{TRUE}.}
 
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{required}{(\code{character} or \code{NULL}) optional name of a variable that is required to be non-missing.}
+\item{required}{(\code{character} or \code{NULL})\cr optional name of a variable that is required to be non-missing.}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
 
@@ -78,7 +78,7 @@ by a statistics function.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{indent_mod}{(\code{count}) \cr it can be negative. Modifier for the default indent position for the
+\item{indent_mod}{(\code{count})\cr it can be negative. Modifier for the default indent position for the
 structure created by this function(subtable, content table, or row) and
 all of that structure's children. Defaults to 0, which corresponds to the
 unmodified default behavior.}
@@ -91,10 +91,10 @@ unmodified default behavior.}
 }
 \value{
 A list with:
-\itemize{
-\item \code{unique}: vector of count and percentage.
-\item \code{nonunique} : vector of count.
-\item \code{unique_count}: count.
+\describe{
+\item{unique}{vector of count and percentage.}
+\item{nonunique}{vector of count.}
+\item{unique_count}{count.}
 }
 }
 \description{
@@ -140,6 +140,7 @@ s_num_patients(
   .N_col = 6L,
   count_by = as.character(c(1, 1, 2, 1, 1, 1))
 )
+
 # Count number of unique and non-unique patients.
 df <- data.frame(
   USUBJID = as.character(c(1, 2, 1, 4, NA)),

--- a/man/summarize_patients_exposure_in_cols.Rd
+++ b/man/summarize_patients_exposure_in_cols.Rd
@@ -25,12 +25,12 @@ summarize_patients_exposure_in_cols(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var, var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{id}{(\code{string}) \cr subject variable name.}
+\item{id}{(\code{string})\cr subject variable name.}
 
 \item{labelstr}{(\code{character})\cr label of the level of the parent split currently being summarized
 (must be present as second argument in Content Row Functions).}
@@ -51,14 +51,14 @@ be used as label.}
 
 \item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 
-\item{col_split}{(\code{flag})\cr whether the columns should be split.
-Set to \code{FALSE} when the required column split has been done already earlier in the layout pipe.}
+\item{col_split}{(\code{flag})\cr whether the columns should be split. Set to \code{FALSE} when the required
+column split has been done already earlier in the layout pipe.}
 }
 \value{
-\code{\link[=s_count_patients_sum_exposure]{s_count_patients_sum_exposure()}} returns a list with the statistics:\cr
-\itemize{
-\item \code{n_patients}: number of unique patients in \code{df}.
-\item \code{sum_exposure}: sum of \code{.var} across all patients in \code{df}.
+\code{\link[=s_count_patients_sum_exposure]{s_count_patients_sum_exposure()}} returns a list with the statistics:
+\describe{
+\item{n_patients}{number of unique patients in \code{df}.}
+\item{sum_exposure}{sum of \code{.var} across all patients in \code{df}.}
 }
 }
 \description{
@@ -101,7 +101,6 @@ s_count_patients_sum_exposure(
   custom_label = "some user's custom label"
 )
 }
-
 
 lyt <- basic_table() \%>\%
   split_cols_by("ARMCD", split_fun = add_overall_level("Total", first = FALSE)) \%>\%

--- a/man/summarize_variables.Rd
+++ b/man/summarize_variables.Rd
@@ -124,10 +124,12 @@ summarize_vars(
 
 \item{na.rm}{(\code{flag})\cr whether \code{NA} values should be removed from \code{x} prior to analysis.}
 
-\item{denom}{(\code{string})\cr choice of denominator for proportion:\cr
-can be \code{n} (number of values in this row and column intersection), \code{N_row} (total
-number of values in this row across columns), or \code{N_col} (total number of values in
-this column across rows).}
+\item{denom}{(\code{string})\cr choice of denominator for proportion. Options are:
+\itemize{
+\item \code{n}: number of values in this row and column intersection.
+\item \code{N_row}: total number of values in this row across columns.
+\item \code{N_col}: total number of values in this column across rows.
+}}
 
 \item{.N_row}{(\code{count})\cr column-wise N (column count) for the full column that is passed by \code{rtables}.}
 
@@ -141,14 +143,14 @@ by a statistics function.}
 
 \item{...}{arguments passed to \code{s_summary()}.}
 
-\item{control}{a (\code{list}) of parameters for descriptive statistics details, specified by using \cr
-the helper function \code{\link[=control_summarize_vars]{control_summarize_vars()}}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for descriptive statistics details, specified by using
+the helper function \code{\link[=control_summarize_vars]{control_summarize_vars()}}. Some possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for mean and median.
-\item \code{quantiles}: numeric vector of length two to specify the quantiles.
-\item \code{quantile_type} (\code{numeric}) \cr between 1 and 9 selecting quantile algorithms to be used. \cr
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for mean and median.
+\item \code{quantiles} (\code{numeric})\cr vector of length two to specify the quantiles.
+\item \code{quantile_type} (\code{numeric})\cr between 1 and 9 selecting quantile algorithms to be used.
 See more about \code{type} in \code{\link[stats:quantile]{stats::quantile()}}.
-\item \code{test_mean}: (\code{numeric}) \cr to test against the mean under the null hypothesis when calculating p-value.
+\item \code{test_mean} (\code{numeric})\cr value to test against the mean under the null hypothesis when calculating p-value.
 }}
 
 \item{verbose}{defaults to \code{TRUE}. It prints out warnings and messages. It is mainly used
@@ -179,50 +181,50 @@ to avoid warnings from \code{rtables}.}
 \item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
-If \code{x} is of class \code{numeric}, returns a list with named items: \cr
-\itemize{
-\item \code{n}: the \code{\link[=length]{length()}} of \code{x}.
-\item \code{sum}: the \code{\link[=sum]{sum()}} of \code{x}.
-\item \code{mean}: the \code{\link[=mean]{mean()}} of \code{x}.
-\item \code{sd}: the \code{\link[stats:sd]{stats::sd()}} of \code{x}.
-\item \code{se}: the standard error of \code{x} mean, i.e.: (\verb{sd()/sqrt(length())]}).
-\item \code{mean_sd}: the \code{\link[=mean]{mean()}} and \code{\link[stats:sd]{stats::sd()}} of \code{x}.
-\item \code{mean_se}: the \code{\link[=mean]{mean()}} of \code{x} and its standard error (see above).
-\item \code{mean_ci}: the CI for the mean of \code{x} (from \code{\link[=stat_mean_ci]{stat_mean_ci()}}).
-\item \code{mean_sei}: the SE interval for the mean of \code{x}, i.e.: (\code{\link[=mean]{mean()}} -/+ \code{\link[stats:sd]{stats::sd()}}/\code{\link[=sqrt]{sqrt()}}).
-\item \code{mean_sdi}: the SD interval for the mean of \code{x}, i.e.: (\code{\link[=mean]{mean()}} -/+ \code{\link[stats:sd]{stats::sd()}}).
-\item \code{mean_pval}: the two-sided p-value of the mean of \code{x} (from \code{\link[=stat_mean_pval]{stat_mean_pval()}}).
-\item \code{median}: the \code{\link[stats:median]{stats::median()}} of \code{x}.
-\item \code{mad}:
-the median absolute deviation of \code{x}, i.e.: (\code{\link[stats:median]{stats::median()}} of \code{xc}, where \code{xc} = \code{x} - \code{\link[stats:median]{stats::median()}}).
-\item \code{median_ci}: the CI for the median of \code{x} (from \code{\link[=stat_median_ci]{stat_median_ci()}}).
-\item \code{quantiles}: two sample quantiles of \code{x} (from \code{\link[stats:quantile]{stats::quantile()}}).
-\item \code{iqr}: the \code{\link[stats:IQR]{stats::IQR()}} of \code{x}.
-\item \code{range}: the \code{\link[=range_noinf]{range_noinf()}} of \code{x}.
-\item \code{min}: the \code{\link[=max]{max()}} of \code{x}.
-\item \code{max}: the \code{\link[=min]{min()}} of \code{x}.
-\item \code{cv}: the coefficient of variation of \code{x}, i.e.: (\code{sd()/mean() * 100}).
-\item \code{geom_mean}: the geometric mean of \code{x}, i.e.: (\code{exp(mean(log(x)))}).
-\item \code{geom_cv}: the geometric coefficient of variation of \code{x}, i.e.: (\code{sqrt(exp(sd(log(x))^2) - 1)*100}).
+If \code{x} is of class \code{numeric}, returns a list with the following named \code{numeric} items:
+\describe{
+\item{n}{the \code{\link[=length]{length()}} of \code{x}.}
+\item{sum}{the \code{\link[=sum]{sum()}} of \code{x}.}
+\item{mean}{the \code{\link[=mean]{mean()}} of \code{x}.}
+\item{sd}{the \code{\link[stats:sd]{stats::sd()}} of \code{x}.}
+\item{se}{the standard error of \code{x} mean, i.e.: (\code{sd(x) / sqrt(length(x))}).}
+\item{mean_sd}{the \code{\link[=mean]{mean()}} and \code{\link[stats:sd]{stats::sd()}} of \code{x}.}
+\item{mean_se}{the \code{\link[=mean]{mean()}} of \code{x} and its standard error (see above).}
+\item{mean_ci}{the CI for the mean of \code{x} (from \code{\link[=stat_mean_ci]{stat_mean_ci()}}).}
+\item{mean_sei}{the SE interval for the mean of \code{x}, i.e.: (\code{\link[=mean]{mean()}} -/+ \code{\link[stats:sd]{stats::sd()}} / \code{\link[=sqrt]{sqrt()}}).}
+\item{mean_sdi}{the SD interval for the mean of \code{x}, i.e.: (\code{\link[=mean]{mean()}} -/+ \code{\link[stats:sd]{stats::sd()}}).}
+\item{mean_pval}{the two-sided p-value of the mean of \code{x} (from \code{\link[=stat_mean_pval]{stat_mean_pval()}}).}
+\item{median}{the \code{\link[stats:median]{stats::median()}} of \code{x}.}
+\item{mad}{the median absolute deviation of \code{x}, i.e.: (\code{\link[stats:median]{stats::median()}} of \code{xc},
+where \code{xc} = \code{x} - \code{\link[stats:median]{stats::median()}}).
+}
+\item{median_ci}{the CI for the median of \code{x} (from \code{\link[=stat_median_ci]{stat_median_ci()}}).}
+\item{quantiles}{two sample quantiles of \code{x} (from \code{\link[stats:quantile]{stats::quantile()}}).}
+\item{iqr}{the \code{\link[stats:IQR]{stats::IQR()}} of \code{x}.}
+\item{range}{the \code{\link[=range_noinf]{range_noinf()}} of \code{x}.}
+\item{min}{the \code{\link[=max]{max()}} of \code{x}.}
+\item{max}{the \code{\link[=min]{min()}} of \code{x}.}
+\item{cv}{the coefficient of variation of \code{x}, i.e.: (\code{\link[stats:sd]{stats::sd()}} / \code{\link[=mean]{mean()}} * 100).}
+\item{geom_mean}{the geometric mean of \code{x}, i.e.: (\code{exp(mean(log(x)))}).}
+\item{geom_cv}{the geometric coefficient of variation of \code{x}, i.e.: (\code{sqrt(exp(sd(log(x)) ^ 2) - 1) * 100}).}
 }
 
-If \code{x} is of class \code{factor} or converted from \code{character}, returns a list with
-named items:
-\itemize{
-\item \code{n}: the \code{\link[=length]{length()}} of \code{x}.
-\item \code{count}: a list with the number of cases for each level of the
-factor \code{x}
-\item \code{count_fraction}: similar to \code{count} but also includes the proportion of cases for each level of the
+If \code{x} is of class \code{factor} or converted from \code{character}, returns a list with named \code{numeric} items:
+\describe{
+\item{n}{the \code{\link[=length]{length()}} of \code{x}.}
+\item{count}{a list with the number of cases for each level of the factor \code{x}.}
+\item{count_fraction}{similar to \code{count} but also includes the proportion of cases for each level of the
 factor \code{x} relative to the denominator, or \code{NA} if the denominator is zero.
 }
+}
 
-If \code{x} is of class \code{logical}, returns a list with named items:
-\itemize{
-\item \code{n}: the \code{\link[=length]{length()}} of \code{x} (possibly after removing \code{NA}s).
-\item \code{count}: count of \code{TRUE} in \code{x}.
-\item \code{count_fraction}: count and proportion of \code{TRUE} in \code{x} relative to the denominator,
-or \code{NA} if the denominator is zero. Note that \code{NA}s in \code{x} are never counted or leading
-to \code{NA} here.
+If \code{x} is of class \code{logical}, returns a list with named \code{numeric} items:
+\describe{
+\item{n}{the \code{\link[=length]{length()}} of \code{x} (possibly after removing \code{NA}s).}
+\item{count}{count of \code{TRUE} in \code{x}.}
+\item{count_fraction}{count and proportion of \code{TRUE} in \code{x} relative to the denominator, or \code{NA} if the
+denominator is zero. Note that \code{NA}s in \code{x} are never counted or leading to \code{NA} here.
+}
 }
 }
 \description{
@@ -324,6 +326,7 @@ basic_table() \%>\%
 ## By comparison with `lapply`:
 X <- split(dta_test, f = with(dta_test, interaction(Group, sub_group)))
 lapply(X, function(x) s_summary(x$x))
+
 # `s_summary.factor`
 
 ## Basic usage:
@@ -341,6 +344,7 @@ s_summary(x, na.rm = FALSE)
 x <- factor(c("a", "a", "b", "c", "a"))
 s_summary(x, denom = "N_row", .N_row = 10L)
 s_summary(x, denom = "N_col", .N_col = 20L)
+
 # `s_summary.character`
 
 ## Basic usage:
@@ -360,6 +364,7 @@ s_summary(x, na.rm = FALSE)
 x <- c(TRUE, FALSE, TRUE, TRUE)
 s_summary(x, denom = "N_row", .N_row = 10L)
 s_summary(x, denom = "N_col", .N_col = 20L)
+
 # `a_summary.numeric`
 a_summary(rnorm(10), .N_col = 10, .N_row = 20, .var = "bla")
 # `a_summary.factor`

--- a/man/survival_biomarkers_subgroups.Rd
+++ b/man/survival_biomarkers_subgroups.Rd
@@ -15,15 +15,16 @@ tabulate_survival_biomarkers(
 \item{df}{(\code{data.frame})\cr containing all analysis variables, as returned by
 \code{\link[=extract_survival_biomarkers]{extract_survival_biomarkers()}}.}
 
-\item{vars}{(\code{character})\cr the name of statistics to be reported among
-\code{n_tot_events} (total number of events per group),
-\code{n_tot} (total number of observations per group),
-\code{median} (median survival time),
-\code{hr} (hazard ratio),
-\code{ci} (confidence interval of hazard ratio) and
-\code{pval} (p value of the effect).
-Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as both \code{hr} and \code{ci}
-are required.}
+\item{vars}{(\code{character})\cr the names of statistics to be reported among:
+\itemize{
+\item \code{n_tot_events}: total number of events per group.
+\item \code{n_tot}: total number of observations per group.
+\item \code{median}: median survival time.
+\item \code{hr}: hazard ratio.
+\item \code{ci}: confidence interval of hazard ratio.
+\item \code{pval}: p-value of the effect.
+Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as both \code{hr} and \code{ci} are required.
+}}
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips
 displaying unit.}

--- a/man/survival_coxph_pairwise.Rd
+++ b/man/survival_coxph_pairwise.Rd
@@ -41,9 +41,9 @@ coxph_pairwise(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -52,17 +52,16 @@ by a statistics function.}
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{strat}{(\code{character} or \code{NULL}) variable names indicating stratification factors.}
+\item{strat}{(\code{character} or \code{NULL})\cr variable names indicating stratification factors.}
 
-\item{control}{(\code{list}) \cr parameters for comparison details, specified by using \cr
-the helper function \code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for comparison details, specified by using the helper function
+\code{\link[=control_coxph]{control_coxph()}}. Some possible parameter options are:
 \itemize{
-\item \code{pval_method}: (\code{string}) \cr p-value method for testing hazard ratio = 1.
-Default method is "log-rank" which comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood"
-that comes from \code{\link[survival:coxph]{survival::coxph()}}.
-\item \code{ties}: (\code{string}) \cr specifying the method for tie handling. Default is "efron",
+\item \code{pval_method} (\code{string})\cr p-value method for testing hazard ratio = 1. Default method is "log-rank" which
+comes from \code{\link[survival:survdiff]{survival::survdiff()}}, can also be set to "wald" or "likelihood" (from \code{\link[survival:coxph]{survival::coxph()}}).
+\item \code{ties} (\code{string})\cr specifying the method for tie handling. Default is "efron",
 can also be set to "breslow" or "exact". See more in \code{\link[survival:coxph]{survival::coxph()}}
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for HR.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for HR.
 }}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -88,12 +87,12 @@ to avoid warnings from \code{rtables}.}
 }
 \value{
 The statistics are:
-\itemize{
-\item \code{pvalue} : p-value to test HR = 1.
-\item \code{hr} : hazard ratio.
-\item \code{hr_ci} : confidence interval for hazard ratio.
-\item \code{n_tot} : total number of observations
-\item \code{n_tot_events} : total number of events
+\describe{
+\item{pvalue}{p-value to test HR = 1.}
+\item{hr}{hazard ratio.}
+\item{hr_ci}{confidence interval for hazard ratio.}
+\item{n_tot}{total number of observations.}
+\item{n_tot_events}{total number of events.}
 }
 }
 \description{

--- a/man/survival_duration_subgroups.Rd
+++ b/man/survival_duration_subgroups.Rd
@@ -42,7 +42,7 @@ are required.}
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips
 displaying unit.}
 
-\item{data}{(\verb{data frame})\cr the dataset containing the variables to summarize.}
+\item{data}{(\code{data.frame})\cr the dataset containing the variables to summarize.}
 
 \item{groups_lists}{(named \code{list} of \code{list})\cr optionally contains for each \code{subgroups} variable a
 list, which specifies the new group levels via the names and the

--- a/man/survival_time.Rd
+++ b/man/survival_time.Rd
@@ -24,20 +24,20 @@ surv_time(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{control}{a (\code{list}) of parameters for comparison details, specified by using \cr
-the helper function \link{control_surv_time}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for comparison details, specified by using the helper function
+\code{\link[=control_surv_time]{control_surv_time()}}. Some possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for survival time.
-\item \code{conf_type}: (\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-see more in \code{\link[survival:survfit]{survival::survfit()}}. Note option, "none" is not supported.
-\item \code{quantiles}: numeric vector of length two to specify the quantiles of survival time.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for survival time.
+\item \code{conf_type} (\code{string})\cr confidence interval type. Options are "plain" (default), "log", or "log-log",
+see more in \code{\link[survival:survfit]{survival::survfit()}}. Note option "none" is not supported.
+\item \code{quantiles} (\code{numeric})\cr vector of length two to specify the quantiles of survival time.
 }}
 
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -61,20 +61,20 @@ to avoid warnings from \code{rtables}.}
 }
 \value{
 The statistics are:
-\itemize{
-\item \code{median} : median survival time.
-\item \code{median_ci} : confidence interval for median time.
-\item \code{quantiles} : survival time for two specified quantiles.
-\item \code{range_censor} : survival time range for censored observations.
-\item \code{range_event} : survival time range for observations with events.
-\item \code{range} : survival time range for all observations.
+\describe{
+\item{median}{median survival time.}
+\item{median_ci}{confidence interval for median time.}
+\item{quantiles}{survival time for two specified quantiles.}
+\item{range_censor}{survival time range for censored observations.}
+\item{range_event}{survival time range for observations with events.}
+\item{range}{survival time range for all observations.}
 }
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Summarize median survival time and CIs, percentiles of survival times, \cr
-survival time range of censored/event patients.
+Summarize median survival time and CIs, percentiles of survival times, survival
+time range of censored/event patients.
 }
 \section{Functions}{
 \itemize{

--- a/man/survival_timepoint.Rd
+++ b/man/survival_timepoint.Rd
@@ -61,25 +61,25 @@ surv_timepoint(
 )
 }
 \arguments{
-\item{df}{(\verb{data frame})\cr data set containing all analysis variables.}
+\item{df}{(\code{data.frame})\cr data set containing all analysis variables.}
 
 \item{.var}{(\code{string})\cr single variable name that is passed by \code{rtables} when requested
 by a statistics function.}
 
-\item{time_point}{(\code{number}) \cr survival time point of interest.}
+\item{time_point}{(\code{number})\cr survival time point of interest.}
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{control}{a (\code{list}) of parameters for comparison details, specified by using \cr
-the helper function \code{\link{control_surv_timepoint}}. Some possible parameter options are: \cr
+\item{control}{(\code{list})\cr parameters for comparison details, specified by using the helper function
+\code{\link[=control_surv_timepoint]{control_surv_timepoint()}}. Some possible parameter options are:
 \itemize{
-\item \code{conf_level}: (\code{proportion})\cr confidence level of the interval for survival rate.
-\item \code{conf_type}: (\code{string}) \cr "plain" (default), "log", "log-log" for confidence interval type, \cr
-see more in \code{\link[survival:survfit]{survival::survfit()}}. Note that the option "none" is no longer supported.
-\item \code{time_point}: (\code{number}) \cr survival time point of interest.
+\item \code{conf_level} (\code{proportion})\cr confidence level of the interval for survival rate.
+\item \code{conf_type} (\code{string})\cr confidence interval type. Options are "plain" (default), "log", "log-log",
+see more in \code{\link[survival:survfit]{survival::survfit()}}. Note option "none" is no longer supported.
+\item \code{time_point} (\code{number})\cr survival time point of interest.
 }}
 
-\item{.ref_group}{(\verb{data frame} or \code{vector})\cr the data corresponding to the reference group.}
+\item{.ref_group}{(\code{data.frame} or \code{vector})\cr the data corresponding to the reference group.}
 
 \item{.in_ref_col}{(\code{logical})\cr \code{TRUE} when working with the reference level, \code{FALSE} otherwise.}
 
@@ -109,24 +109,24 @@ avoid warnings from duplicate table names.}
 }
 \value{
 The statistics are:
-\itemize{
-\item \code{pt_at_risk} : patients remaining at risk.
-\item \code{event_free_rate} : event free rate (\%).
-\item \code{rate_se} : standard error of event free rate.
-\item \code{rate_ci} : confidence interval for event free rate.
+\describe{
+\item{pt_at_risk}{patients remaining at risk.}
+\item{event_free_rate}{event free rate (\%).}
+\item{rate_se}{standard error of event free rate.}
+\item{rate_ci}{confidence interval for event free rate.}
 }
 
 The statistics are:
-\itemize{
-\item \code{rate_diff} : event free rate difference between two groups.
-\item \code{rate_diff_ci} : confidence interval for the difference.
-\item \code{ztest_pval} : p-value to test the difference is 0.
+\describe{
+\item{rate_diff}{event free rate difference between two groups.}
+\item{rate_diff_ci}{confidence interval for the difference.}
+\item{ztest_pval}{p-value to test the difference is 0.}
 }
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Summarize patient's survival rate and difference of survival rates between groups at a time point.
+Summarize patients' survival rate and difference of survival rates between groups at a time point.
 }
 \section{Functions}{
 \itemize{

--- a/man/univariate.Rd
+++ b/man/univariate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/coxph.R
 \name{univariate}
 \alias{univariate}
-\title{Univariate formula special term}
+\title{Univariate Formula Special Term}
 \usage{
 univariate(x)
 }

--- a/man/update_weights_strat_wilson.Rd
+++ b/man/update_weights_strat_wilson.Rd
@@ -15,26 +15,20 @@ update_weights_strat_wilson(
 )
 }
 \arguments{
-\item{vars}{(\code{numeric}) \cr
-normalized proportions for each strata.}
+\item{vars}{(\code{numeric})\cr normalized proportions for each strata.}
 
-\item{strata_qnorm}{(\code{numeric}) \cr
-initial estimation with identical weights of the quantiles.}
+\item{strata_qnorm}{(\code{numeric})\cr initial estimation with identical weights of the quantiles.}
 
-\item{initial_weights}{(\code{numeric}) \cr
-initial weights used to calculate \code{strata_qnorm}. This can be optimized in
-the future if we need to estimate better initial weights.}
+\item{initial_weights}{(\code{numeric})\cr initial weights used to calculate \code{strata_qnorm}. This can
+be optimized in the future if we need to estimate better initial weights.}
 
-\item{n_per_strata}{(\code{numeric}) \cr
-number of elements in each strata.}
+\item{n_per_strata}{(\code{numeric})\cr number of elements in each strata.}
 
-\item{max_iterations}{(\code{count}) \cr
-maximum number of iterations to be tried. Convergence is always checked.}
+\item{max_iterations}{(\code{count})\cr maximum number of iterations to be tried. Convergence is always checked.}
 
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
-\item{tol}{(\code{number}) \cr
-tolerance threshold for convergence.}
+\item{tol}{(\code{number})\cr tolerance threshold for convergence.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}


### PR DESCRIPTION
Many changes to Roxygen documentation with very few changes to actual output/formatting. 

Changes to `\cr` characters will hopefully resolve #825. Also added missing `surv_*` functions to pkgdown reference, tidied some parameter definitions, and reformatted bullet lists for consistency. 