### PR TITLE
Fix tibble snapshots

### DIFF
--- a/tests/testthat/_snaps/abnormal_by_worst_grade_worsen.md
+++ b/tests/testthat/_snaps/abnormal_by_worst_grade_worsen.md
@@ -3,47 +3,51 @@
     Code
       res
     Output
-      # A tibble: 20 x 8
-      # Groups:   USUBJID, PARAMCD [15]
-         USUBJID PARAMCD   VALUES     MIN   MAX WGRLOFL WGRHIFL GRADDR
-         <chr>   <chr>      <dbl>   <dbl> <dbl> <chr>   <chr>   <chr> 
-       1 4       ABC       0.0478  0.0478  187. "Y"     ""      Low   
-       2 3       OPQ       0.314   0.314   144. "Y"     ""      Low   
-       3 4       OPQ       0.455   0.455   193. "Y"     ""      Low   
-       4 2       ABC       0.790   0.790   181. "Y"     ""      Low   
-       5 2       OPQ       7.49    7.49    195. "Y"     ""      Low   
-       6 5       OPQ      22.7    22.7     187. "Y"     ""      Low   
-       7 1       OPQ      23.5    23.5     196. "Y"     ""      Low   
-       8 1       ABC      26.9    26.9     187. "Y"     ""      Low   
-       9 3       ABC      37.9    37.9     197. "Y"     ""      Low   
-      10 5       ABC      46.7    46.7     193. "Y"     ""      Low   
-      11 3       OPQ     144.      0.314   144. ""      "Y"     High  
-      12 3       XYZ     155.     17.1     155. ""      "Y"     High  
-      13 2       XYZ     157.      7.79    157. ""      "Y"     High  
-      14 4       XYZ     167.      0.276   167. ""      "Y"     High  
-      15 5       OPQ     187.     22.7     187. ""      "Y"     High  
-      16 5       XYZ     189.     16.1     189. ""      "Y"     High  
-      17 4       OPQ     193.      0.455   193. ""      "Y"     High  
-      18 2       OPQ     195.      7.49    195. ""      "Y"     High  
-      19 1       OPQ     196.     23.5     196. ""      "Y"     High  
-      20 1       XYZ     198.     16.5     198. ""      "Y"     High  
+         USUBJID PARAMCD       VALUES         MIN      MAX WGRLOFL WGRHIFL GRADDR
+      1        4     ABC   0.04777932  0.04777932 186.6068       Y            Low
+      2        3     OPQ   0.31411084  0.31411084 143.8712       Y            Low
+      3        4     OPQ   0.45459322  0.45459322 192.5216       Y            Low
+      4        2     ABC   0.78966776  0.78966776 181.3203       Y            Low
+      5        2     OPQ   7.48620657  7.48620657 194.7080       Y            Low
+      6        5     OPQ  22.74372182 22.74372182 187.4772       Y            Low
+      7        1     OPQ  23.49747233 23.49747233 195.6453       Y            Low
+      8        1     ABC  26.93331945 26.93331945 187.4151       Y            Low
+      9        3     ABC  37.89478708 37.89478708 196.5634       Y            Low
+      10       5     ABC  46.70470511 46.70470511 192.5141       Y            Low
+      11       3     OPQ 143.87116753  0.31411084 143.8712               Y   High
+      12       3     XYZ 155.16467253 17.12241299 155.1647               Y   High
+      13       2     XYZ 156.93855514  7.78729822 156.9386               Y   High
+      14       4     XYZ 167.36031189  0.27616872 167.3603               Y   High
+      15       5     OPQ 187.47716993 22.74372182 187.4772               Y   High
+      16       5     XYZ 188.94406511 16.05289332 188.9441               Y   High
+      17       4     OPQ 192.52160275  0.45459322 192.5216               Y   High
+      18       2     OPQ 194.70798275  7.48620657 194.7080               Y   High
+      19       1     OPQ 195.64528568 23.49747233 195.6453               Y   High
+      20       1     XYZ 197.77834578 16.48751162 197.7783               Y   High
 
 # h_adlb_worsen stacks data correctly
 
     Code
       res
     Output
-      # A tibble: 8 x 9
-        USUBJID              ARMCD AVISIT PARAMCD ATOXGR BTOXGR WGRLOFL WGRHIFL GRADDR
-        <chr>                <fct> <fct>  <chr>   <fct>  <fct>  <chr>   <chr>   <chr> 
-      1 AB12345-CHN-1-id-53  ARM B WEEK ~ IGA     0      0      ""      "Y"     High  
-      2 AB12345-CHN-3-id-128 ARM B WEEK ~ IGA     4      0      ""      "Y"     High  
-      3 AB12345-CHN-1-id-53  ARM B WEEK ~ ALT     4      0      ""      "Y"     High  
-      4 AB12345-CHN-3-id-128 ARM B WEEK ~ ALT     1      0      ""      "Y"     High  
-      5 AB12345-CHN-1-id-53  ARM B WEEK ~ CRP     0      1      "Y"     "Y"     Low   
-      6 AB12345-CHN-3-id-128 ARM B WEEK ~ CRP     0      0      "Y"     ""      Low   
-      7 AB12345-CHN-1-id-53  ARM B WEEK ~ ALT     -4     0      "Y"     ""      Low   
-      8 AB12345-CHN-3-id-128 ARM B WEEK ~ ALT     -4     0      "Y"     ""      Low   
+                     USUBJID ARMCD        AVISIT PARAMCD ATOXGR BTOXGR WGRLOFL
+      1  AB12345-CHN-1-id-53 ARM B  WEEK 1 DAY 8     IGA      0      0        
+      2 AB12345-CHN-3-id-128 ARM B WEEK 5 DAY 36     IGA      4      0        
+      3  AB12345-CHN-1-id-53 ARM B WEEK 3 DAY 22     ALT      4      0        
+      4 AB12345-CHN-3-id-128 ARM B WEEK 4 DAY 29     ALT      1      0        
+      5  AB12345-CHN-1-id-53 ARM B WEEK 3 DAY 22     CRP      0      1       Y
+      6 AB12345-CHN-3-id-128 ARM B  WEEK 1 DAY 8     CRP      0      0       Y
+      7  AB12345-CHN-1-id-53 ARM B WEEK 5 DAY 36     ALT     -4      0       Y
+      8 AB12345-CHN-3-id-128 ARM B WEEK 5 DAY 36     ALT     -4      0       Y
+        WGRHIFL GRADDR
+      1       Y   High
+      2       Y   High
+      3       Y   High
+      4       Y   High
+      5       Y    Low
+      6            Low
+      7            Low
+      8            Low
 
 # h_worsen_counter counts data (low) correctly
 
@@ -220,56 +224,4 @@
           3      4/68 (5.9%)    9/70 (12.9%)     5/53 (9.4%) 
           4     7/69 (10.1%)     6/72 (8.3%)     4/55 (7.3%) 
           Any   30/69 (43.5%)   26/72 (36.1%)   19/55 (34.5%)
-
-# h_adlb_worsen all high
-
-    Code
-      res
-    Output
-      # A tibble: 600 x 51
-         STUDYID COUNTRY SITEID SUBJID   AGE SEX   ARMCD ARM      ACTAR~1 ACTARM RACE 
-         <chr>   <fct>   <chr>  <chr>  <dbl> <fct> <fct> <fct>    <fct>   <fct>  <fct>
-       1 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       2 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       3 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       4 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       5 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       6 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       7 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       8 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       9 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-      10 AB12345 BRA     BRA-1  id-23   41.3 F     ARM A A: Drug~ ARM A   A: Dr~ AMER~
-      # ... with 590 more rows, 40 more variables: TRTSDTM <dttm>, TRTEDTM <dttm>,
-      #   EOSDY <dbl>, STRATA1 <fct>, STRATA2 <fct>, BMRKR1 <dbl>, BMRKR2 <fct>,
-      #   REGION1 <fct>, SAFFL <fct>, USUBJID <chr>, PARAM <fct>, AVISIT <fct>,
-      #   AVAL <dbl>, LBCAT <fct>, PARAMCD <chr>, AVALU <fct>, AVISITN <dbl>,
-      #   ABLFL2 <chr>, ABLFL <chr>, BASE <dbl>, BASETYPE <chr>, ANRIND <fct>,
-      #   ANRLO <dbl>, ANRHI <dbl>, DTYPE <lgl>, ATOXGR <fct>, BTOXGR <fct>,
-      #   ATOXDSCL <chr>, ATOXDSCH <chr>, ADTM <dttm>, ASPID <int>, LBSEQ <int>, ...
-
-# h_adlb_worsen all low
-
-    Code
-      res
-    Output
-      # A tibble: 600 x 51
-         STUDYID COUNTRY SITEID SUBJID   AGE SEX   ARMCD ARM      ACTAR~1 ACTARM RACE 
-         <chr>   <fct>   <chr>  <chr>  <dbl> <fct> <fct> <fct>    <fct>   <fct>  <fct>
-       1 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       2 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       3 AB12345 BRA     BRA-1  id-105  37.8 F     ARM A A: Drug~ ARM A   A: Dr~ ASIAN
-       4 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       5 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       6 AB12345 BRA     BRA-1  id-171  29.8 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       7 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       8 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-       9 AB12345 BRA     BRA-1  id-177  38.9 F     ARM B B: Plac~ ARM B   B: Pl~ ASIAN
-      10 AB12345 BRA     BRA-1  id-23   41.3 F     ARM A A: Drug~ ARM A   A: Dr~ AMER~
-      # ... with 590 more rows, 40 more variables: TRTSDTM <dttm>, TRTEDTM <dttm>,
-      #   EOSDY <dbl>, STRATA1 <fct>, STRATA2 <fct>, BMRKR1 <dbl>, BMRKR2 <fct>,
-      #   REGION1 <fct>, SAFFL <fct>, USUBJID <chr>, PARAM <fct>, AVISIT <fct>,
-      #   AVAL <dbl>, LBCAT <fct>, PARAMCD <chr>, AVALU <fct>, AVISITN <dbl>,
-      #   ABLFL2 <chr>, ABLFL <chr>, BASE <dbl>, BASETYPE <chr>, ANRIND <fct>,
-      #   ANRLO <dbl>, ANRHI <dbl>, DTYPE <lgl>, ATOXGR <fct>, BTOXGR <fct>,
-      #   ATOXDSCL <chr>, ATOXDSCH <chr>, ADTM <dttm>, ASPID <int>, LBSEQ <int>, ...
 

--- a/tests/testthat/_snaps/h_map_for_count_abnormal.md
+++ b/tests/testthat/_snaps/h_map_for_count_abnormal.md
@@ -3,113 +3,78 @@
     Code
       res
     Output
-      # A tibble: 6 x 2
-      # Groups:   PARAM [2]
         PARAM ANRIND
-        <chr> <chr> 
-      1 ALT   HIGH  
-      2 ALT   LOW   
-      3 ALT   NORMAL
-      4 CPR   HIGH  
-      5 CPR   LOW   
-      6 CPR   NORMAL
+      1   ALT   HIGH
+      2   ALT    LOW
+      3   ALT NORMAL
+      4   CPR   HIGH
+      5   CPR    LOW
+      6   CPR NORMAL
 
 # h_map_for_count_abnormal returns the correct map for range method with healthy single input
 
     Code
       res
     Output
-      # A tibble: 6 x 2
-      # Groups:   PARAM [2]
         PARAM ANRIND
-        <chr> <chr> 
-      1 ALT   HIGH  
-      2 ALT   LOW   
-      3 ALT   NORMAL
-      4 CPR   HIGH  
-      5 CPR   LOW   
-      6 CPR   NORMAL
+      1   ALT   HIGH
+      2   ALT    LOW
+      3   ALT NORMAL
+      4   CPR   HIGH
+      5   CPR    LOW
+      6   CPR NORMAL
 
 # h_map_for_count_abnormal returns the correct map for default method with unused LOW LOW/HIGH HIGH input
 
     Code
       res
     Output
-      # A tibble: 6 x 2
-      # Groups:   PARAM [2]
         PARAM ANRIND
-        <chr> <chr> 
-      1 ALT   HIGH  
-      2 ALT   LOW   
-      3 ALT   NORMAL
-      4 CPR   HIGH  
-      5 CPR   LOW   
-      6 CPR   NORMAL
-
----
-
-    Code
-      res
-    Output
-      # A tibble: 7 x 2
-      # Groups:   PARAM [2]
-        PARAM ANRIND 
-        <chr> <chr>  
-      1 ALT   HIGH   
-      2 ALT   LOW    
-      3 ALT   LOW LOW
-      4 ALT   NORMAL 
-      5 CPR   HIGH   
-      6 CPR   LOW    
-      7 CPR   NORMAL 
+      1   ALT   HIGH
+      2   ALT    LOW
+      3   ALT NORMAL
+      4   CPR   HIGH
+      5   CPR    LOW
+      6   CPR NORMAL
 
 # h_map_for_count_abnormal returns the correct map for range method with unused LOW LOW/HIGH HIGH input
 
     Code
       res
     Output
-      # A tibble: 10 x 2
-      # Groups:   PARAM [2]
-         PARAM ANRIND   
-         <chr> <chr>    
-       1 ALT   HIGH     
-       2 ALT   HIGH HIGH
-       3 ALT   LOW      
-       4 ALT   LOW LOW  
-       5 ALT   NORMAL   
-       6 CPR   HIGH     
-       7 CPR   HIGH HIGH
-       8 CPR   LOW      
-       9 CPR   LOW LOW  
-      10 CPR   NORMAL   
+         PARAM    ANRIND
+      1    ALT      HIGH
+      2    ALT HIGH HIGH
+      3    ALT       LOW
+      4    ALT   LOW LOW
+      5    ALT    NORMAL
+      6    CPR      HIGH
+      7    CPR HIGH HIGH
+      8    CPR       LOW
+      9    CPR   LOW LOW
+      10   CPR    NORMAL
 
 ---
 
     Code
       res
     Output
-      # A tibble: 6 x 2
-      # Groups:   PARAM [2]
         PARAM ANRIND
-        <chr> <chr> 
-      1 ALT   HIGH  
-      2 ALT   LOW   
-      3 ALT   NORMAL
-      4 CPR   HIGH  
-      5 CPR   LOW   
-      6 CPR   NORMAL
+      1   ALT   HIGH
+      2   ALT    LOW
+      3   ALT NORMAL
+      4   CPR   HIGH
+      5   CPR    LOW
+      6   CPR NORMAL
 
 ---
 
     Code
       res
     Output
-      # A tibble: 4 x 2
-      # Groups:   PARAM [2]
         PARAM ANRIND
-        <chr> <chr> 
-      1 ALT   HIGH  
-      2 ALT   NORMAL
-      3 CPR   LOW   
-      4 CPR   NORMAL
+      1   ALT   HIGH
+      2   ALT NORMAL
+      3   CPR    LOW
+      4   CPR NORMAL
 

--- a/tests/testthat/_snaps/h_stack_by_baskets.md
+++ b/tests/testthat/_snaps/h_stack_by_baskets.md
@@ -3,17 +3,24 @@
     Code
       res
     Output
-      # A tibble: 8 x 6
-        STUDYID USUBJID               ASTDTM              AEDECOD       AESEQ SMQ     
-        <fct>   <fct>                 <dttm>              <fct>         <int> <fct>   
-      1 AB12345 AB12345-BRA-11-id-8   2021-12-05 02:02:07 dcd D.2.1.5.3     2 D.2.1.5~
-      2 AB12345 AB12345-BRA-12-id-120 2020-02-05 01:42:29 dcd D.2.1.5.3     2 D.2.1.5~
-      3 AB12345 AB12345-BRA-1-id-171  2022-11-29 12:18:31 dcd C.1.1.1.3     2 C.1.1.1~
-      4 AB12345 AB12345-BRA-1-id-23   2020-07-10 07:32:49 dcd B.2.2.3.1     3 C.1.1.1~
-      5 AB12345 AB12345-BRA-1-id-59   2021-10-10 23:54:46 dcd C.1.1.1.3     4 C.1.1.1~
-      6 AB12345 AB12345-BRA-1-id-9    2021-06-01 14:39:09 dcd C.1.1.1.3     1 C.1.1.1~
-      7 AB12345 AB12345-BRA-11-id-8   2021-12-21 02:02:07 dcd C.1.1.1.3     3 C.1.1.1~
-      8 AB12345 AB12345-BRA-12-id-120 2020-10-01 01:42:29 dcd C.1.1.1.3     3 C.1.1.1~
+        STUDYID               USUBJID              ASTDTM       AEDECOD AESEQ
+      1 AB12345   AB12345-BRA-11-id-8 2021-12-05 02:02:07 dcd D.2.1.5.3     2
+      2 AB12345 AB12345-BRA-12-id-120 2020-02-05 01:42:29 dcd D.2.1.5.3     2
+      3 AB12345  AB12345-BRA-1-id-171 2022-11-29 12:18:31 dcd C.1.1.1.3     2
+      4 AB12345   AB12345-BRA-1-id-23 2020-07-10 07:32:49 dcd B.2.2.3.1     3
+      5 AB12345   AB12345-BRA-1-id-59 2021-10-10 23:54:46 dcd C.1.1.1.3     4
+      6 AB12345    AB12345-BRA-1-id-9 2021-06-01 14:39:09 dcd C.1.1.1.3     1
+      7 AB12345   AB12345-BRA-11-id-8 2021-12-21 02:02:07 dcd C.1.1.1.3     3
+      8 AB12345 AB12345-BRA-12-id-120 2020-10-01 01:42:29 dcd C.1.1.1.3     3
+                                    SMQ
+      1        D.2.1.5.3/A.1.1.1.1 aesi
+      2        D.2.1.5.3/A.1.1.1.1 aesi
+      3 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
+      4 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
+      5 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
+      6 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
+      7 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
+      8 C.1.1.1.3/B.2.2.3.1 aesi(BROAD)
 
 # h_stack_by_baskets returns an empty dataframe with desired variables and labels when there are no adverse events falling within any of the baskets selected
 

--- a/tests/testthat/_snaps/split_cols_by_groups.md
+++ b/tests/testthat/_snaps/split_cols_by_groups.md
@@ -3,12 +3,10 @@
     Code
       res
     Output
-      # A tibble: 3 x 4
-        valname  label         levelcombo exargs    
-        <chr>    <chr>         <list>     <list>    
-      1 AnyGrade Any Grade (%) <chr [5]>  <list [0]>
-      2 Grade34  Grade 3-4 (%) <chr [2]>  <list [0]>
-      3 Grade5   Grade 5 (%)   <chr [1]>  <list [0]>
+         valname         label    levelcombo exargs
+      1 AnyGrade Any Grade (%) 1, 2, 3, 4, 5   NULL
+      2  Grade34 Grade 3-4 (%)          3, 4   NULL
+      3   Grade5   Grade 5 (%)             5   NULL
 
 # combine_groups combines character vectors
 

--- a/tests/testthat/test-abnormal_by_worst_grade_worsen.R
+++ b/tests/testthat/test-abnormal_by_worst_grade_worsen.R
@@ -48,7 +48,7 @@ testthat::test_that("h_adlb_worsen stacks data correctly (simple case)", {
     direction_var = "GRADDR"
   )
 
-  result <- result[order(result$VALUES), ]
+  result <- result[order(result$VALUES), ] %>% data.frame()
 
   p1 <- input_data %>% dplyr::filter(WGRLOFL == "Y" & GRADDR == "L")
   p2 <- input_data %>% dplyr::filter(WGRHIFL == "Y" & GRADDR == "H")
@@ -74,7 +74,9 @@ testthat::test_that("h_adlb_worsen stacks data correctly", {
     direction_var = "GRADDR"
   )
 
-  result <- result %>% dplyr::select(USUBJID, ARMCD, AVISIT, PARAMCD, ATOXGR, BTOXGR, WGRLOFL, WGRHIFL, GRADDR)
+  result <- result %>%
+    dplyr::select(USUBJID, ARMCD, AVISIT, PARAMCD, ATOXGR, BTOXGR, WGRLOFL, WGRHIFL, GRADDR) %>%
+    data.frame()
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
@@ -225,10 +227,9 @@ testthat::test_that("h_adlb_worsen all high", {
     worst_flag_high = c("WGRHIFL" = "Y"),
     direction_var = "GRADDR"
   )
-  result <- result[order(result$USUBJID, result$AVISIT, result$PARAMCD), ]
 
-  res <- testthat::expect_silent(result)
-  testthat::expect_snapshot(res)
+  testthat::expect_true(all(result$WGRHIFL == "Y" & result$GRADDR == "High"))
+  testthat::expect_identical(nrow(result), 600L)
 })
 
 testthat::test_that("h_adlb_worsen all low", {
@@ -247,8 +248,7 @@ testthat::test_that("h_adlb_worsen all low", {
     worst_flag_low = c("WGRLOFL" = "Y"),
     direction_var = "GRADDR"
   )
-  result <- result[order(result$USUBJID, result$AVISIT, result$PARAMCD), ]
 
-  res <- testthat::expect_silent(result)
-  testthat::expect_snapshot(res)
+  testthat::expect_true(all(result$WGRLOFL == "Y" & result$GRADDR == "Low"))
+  testthat::expect_identical(nrow(result), 600L)
 })

--- a/tests/testthat/test-h_map_for_count_abnormal.R
+++ b/tests/testthat/test-h_map_for_count_abnormal.R
@@ -20,7 +20,8 @@ testthat::test_that("h_map_for_count_abnormal returns the correct map for defaul
   # order of anl variable within the split_rows group because the order of split_rows is something we want to check
   result <- result %>%
     dplyr::group_by(PARAM) %>%
-    dplyr::arrange(ANRIND, .by_group = TRUE)
+    dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+    data.frame()
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
@@ -41,7 +42,8 @@ testthat::test_that("h_map_for_count_abnormal returns the correct map for range 
   # order of anl variable within the split_rows group because the order of split_rows is something we want to check
   result <- result %>%
     dplyr::group_by(PARAM) %>%
-    dplyr::arrange(ANRIND, .by_group = TRUE)
+    dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+    data.frame()
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
@@ -62,7 +64,8 @@ testthat::test_that(
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
     result <- result %>%
       dplyr::group_by(PARAM) %>%
-      dplyr::arrange(ANRIND, .by_group = TRUE)
+      dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+      data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)
@@ -88,7 +91,8 @@ testthat::test_that(
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
     result <- result %>%
       dplyr::group_by(PARAM) %>%
-      dplyr::arrange(ANRIND, .by_group = TRUE)
+      dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+      data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)
@@ -112,9 +116,10 @@ testthat::test_that(
 
     # because the function doesn't require the order of anl variable, but for unit test stability, we arrange the
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
-    result <- result %>%
+    result <- result
       dplyr::group_by(PARAM) %>%
-      dplyr::arrange(ANRIND, .by_group = TRUE)
+      dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+        data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)
@@ -142,7 +147,8 @@ testthat::test_that(
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
     result <- result %>%
       dplyr::group_by(PARAM) %>%
-      dplyr::arrange(ANRIND, .by_group = TRUE)
+      dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+      data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)
@@ -169,7 +175,8 @@ testthat::test_that(
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
     result <- result %>%
       dplyr::group_by(PARAM) %>%
-      dplyr::arrange(ANRIND, .by_group = TRUE)
+      dplyr::arrange(ANRIND, .by_group = TRUE) %>%
+      data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)

--- a/tests/testthat/test-h_map_for_count_abnormal.R
+++ b/tests/testthat/test-h_map_for_count_abnormal.R
@@ -117,9 +117,9 @@ testthat::test_that(
     # because the function doesn't require the order of anl variable, but for unit test stability, we arrange the
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
     result <- result
-      dplyr::group_by(PARAM) %>%
+    dplyr::group_by(PARAM) %>%
       dplyr::arrange(ANRIND, .by_group = TRUE) %>%
-        data.frame()
+      data.frame()
 
     res <- testthat::expect_silent(result)
     testthat::expect_snapshot(res)

--- a/tests/testthat/test-h_map_for_count_abnormal.R
+++ b/tests/testthat/test-h_map_for_count_abnormal.R
@@ -116,8 +116,8 @@ testthat::test_that(
 
     # because the function doesn't require the order of anl variable, but for unit test stability, we arrange the
     # order of anl variable within the split_rows group because the order of split_rows is something we want to check
-    result <- result
-    dplyr::group_by(PARAM) %>%
+    result <- result %>%
+      dplyr::group_by(PARAM) %>%
       dplyr::arrange(ANRIND, .by_group = TRUE) %>%
       data.frame()
 

--- a/tests/testthat/test-h_stack_by_baskets.R
+++ b/tests/testthat/test-h_stack_by_baskets.R
@@ -2,7 +2,7 @@
 adae_local <- tern_ex_adae[1:20, ] %>% df_explicit_na()
 
 testthat::test_that("h_stack_by_baskets returns the correct dataframe", {
-  result <- h_stack_by_baskets(df = adae_local)
+  result <- h_stack_by_baskets(df = adae_local) %>% data.frame()
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)

--- a/tests/testthat/test-split_cols_by_groups.R
+++ b/tests/testthat/test-split_cols_by_groups.R
@@ -5,7 +5,7 @@ testthat::test_that("groups_list_to_df works as expected", {
     "Grade 3-4 (%)" = c("3", "4"),
     "Grade 5 (%)" = "5"
   )
-  result <- groups_list_to_df(grade_groups)
+  result <- groups_list_to_df(grade_groups) %>% data.frame()
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)


### PR DESCRIPTION
Converted most snapshot `tibble`s to `data.frame`s. Replaced 2 unnecessary `tibble` snapshots with different tests.

Closes #866 