### PR TITLE
Fix `a_coxreg` bug for univariate case with no arm and numeric covariate

### DIFF
--- a/R/summarize_coxreg.R
+++ b/R/summarize_coxreg.R
@@ -207,7 +207,11 @@ a_coxreg <- function(df,
   }
   if (!multivar && !var_main) model[, "pval_inter"] <- NA_real_
 
-  if (cov_no_arm) multivar <- TRUE
+  if (cov_no_arm || (!cov_no_arm && !"arm" %in% names(variables) && is.numeric(df[[cov]]))) {
+    multivar <- TRUE
+    if (!cov_no_arm) var_main <- TRUE
+  }
+
   vars_coxreg <- list(which_vars = "all", var_nms = NULL)
   if (eff) {
     if (multivar && !var_main) { # multivar treatment level

--- a/tests/testthat/_snaps/summarize_coxreg.md
+++ b/tests/testthat/_snaps/summarize_coxreg.md
@@ -170,6 +170,21 @@
         Sex (F/M) (reference = F)                                                
           M                                     1.33       (0.97, 1.82)   0.1414 
 
+# summarize_coxreg works with numeric covariate without treatment arm in univariable case
+
+    Code
+      res
+    Output
+                                            Hazard Ratio      90% CI      p-value
+      ———————————————————————————————————————————————————————————————————————————
+      Covariate:                                                                 
+        A Covariate Label (reference = 1)                                 <0.0001
+          2                                     0.45       (0.30, 0.66)   0.0007 
+          3                                     0.31       (0.20, 0.48)   <0.0001
+          4                                     0.18       (0.11, 0.30)   <0.0001
+        Age                                                                      
+          All                                   1.01       (1.00, 1.02)   0.2486 
+
 # summarize_coxreg adds the multivariable Cox regression layer to rtables
 
     Code

--- a/tests/testthat/test-summarize_coxreg.R
+++ b/tests/testthat/test-summarize_coxreg.R
@@ -162,6 +162,20 @@ testthat::test_that("summarize_coxreg works without treatment arm in univariable
   testthat::expect_snapshot(res)
 })
 
+testthat::test_that("summarize_coxreg works with numeric covariate without treatment arm in univariable case", {
+  variables_no_arm <- list(time = "TIME", event = "STATUS", covariates = c("COVAR1", "AGE"))
+
+  result <- basic_table() %>%
+    summarize_coxreg(
+      variables = variables_no_arm,
+      control = control_coxreg(conf_level = 0.90)
+    ) %>%
+    build_table(df = dta_bladder)
+
+  res <- testthat::expect_silent(result)
+  testthat::expect_snapshot(res)
+})
+
 testthat::test_that("summarize_coxreg adds the multivariable Cox regression layer to rtables", {
   variables <- list(time = "TIME", event = "STATUS", arm = "ARMCD", covariates = c("AGE", "COVAR1", "COVAR2"))
 


### PR DESCRIPTION
Closes #891 