### PR TITLE
deprecating `pairwise`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Implemented the `lubridate` package for date variables in `tern` datasets.
 * Organization of `.gitignore` and `.Rbuildignore`.
 * Removed deprecated `footnotes` functions and all related files.
+* Deprecation cycle of `pairwise` function started.
 
 # tern 0.8.0
 

--- a/R/coxph.R
+++ b/R/coxph.R
@@ -1,6 +1,6 @@
 #' Pairwise Formula Special Term
 #'
-#' @description `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("deprecated")`
 #'
 #' The special term `pairwise` indicate that the model should be fitted individually for
 #' every tested level in comparison to the reference level.
@@ -16,6 +16,7 @@
 #'
 #' @export
 pairwise <- function(x) {
+  lifecycle::deprecate_warn("0.8.1.9013", "pairwise()", "univariate()")
   structure(x, varname = deparse(substitute(x)))
 }
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -87,7 +87,6 @@ reference:
       - starts_with("fit_")
       - get_smooths
       - starts_with("logistic_")
-      - pairwise
       - starts_with("tidy.")
       - univariate
 
@@ -172,4 +171,6 @@ reference:
       - starts_with("ex_")
 
   - title: Deprecated Functions
-    desc: No functions are currently deprecated within `tern`.
+    desc: Functions that are currently deprecated within `tern`.
+    contents:
+      - pairwise

--- a/man/pairwise.Rd
+++ b/man/pairwise.Rd
@@ -13,7 +13,7 @@ pairwise(x)
 Variable "paired".
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 The special term \code{pairwise} indicate that the model should be fitted individually for
 every tested level in comparison to the reference level.

--- a/tests/testthat/_snaps/coxph.md
+++ b/tests/testthat/_snaps/coxph.md
@@ -1,19 +1,3 @@
-# pairwise works correctly
-
-    Code
-      res
-    Output
-      
-      Call:
-      lm(formula = SEX ~ pairwise(ARM), data = tern_ex_adsl)
-      
-      Coefficients:
-                      (Intercept)      pairwise(ARM)B: Placebo  
-                        1.4492754                    0.0027794  
-      pairwise(ARM)C: Combination  
-                       -0.0009995  
-      
-
 # univariate works correctly
 
     Code
@@ -22,6 +6,22 @@
       [1] "SEX"  "AGE"  "RACE"
       attr(,"varname")
       [1] "c(\"SEX\", \"AGE\", \"RACE\")"
+
+---
+
+    Code
+      res2
+    Output
+      
+      Call:
+      lm(formula = SEX ~ univariate(ARM), data = tern_ex_adsl)
+      
+      Coefficients:
+                        (Intercept)      univariate(ARM)B: Placebo  
+                          1.4492754                      0.0027794  
+      univariate(ARM)C: Combination  
+                         -0.0009995  
+      
 
 # rht works correctly
 

--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -1,15 +1,13 @@
-testthat::test_that("pairwise works correctly", {
-  suppressWarnings(testthat::expect_warning(result <- lm(SEX ~ pairwise(ARM), data = tern_ex_adsl)))
-
-  res <- testthat::expect_silent(result)
-  testthat::expect_snapshot(res)
-})
-
 testthat::test_that("univariate works correctly", {
   result <- testthat::expect_silent(univariate(c("SEX", "AGE", "RACE")))
 
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
+
+  suppressWarnings(testthat::expect_warning(result2 <- lm(SEX ~ univariate(ARM), data = tern_ex_adsl)))
+
+  res2 <- testthat::expect_silent(result2)
+  testthat::expect_snapshot(res2)
 })
 
 testthat::test_that("rht works correctly", {


### PR DESCRIPTION
Fixes #899 

@danielinteractive fyi. If this function name is anyway needed we can make it an alias as it is identical to `univariate` in the source code