### PR TITLE
Enable `.indent_mods` argument in all analysis functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ### Miscellaneous
 * Updated README to include installation instructions for CRAN.
-* Began deprecation of `indent_mod` argument which is replaced by the `.indent_mods` argument in `summarize_num_patients` and `analyze_num_patients`.
+* Began deprecation of `indent_mod` argument and replace it with the `.indent_mods` argument in `summarize_num_patients` and `analyze_num_patients`.
 
 # tern 0.8.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 ### Enhancements
 * Added explicit zero counts to `g_km` plot "at risk" annotation tables.
+* Implemented `.indent_mods` argument in functions `h_tab_one_biomarker`, `h_tab_rsp_one_biomarker`, `h_tab_surv_one_biomarker`, `summarize_logistic`, `logistic_summary_by_flag`, `tabulate_rsp_biomarkers`, a_coxreg, `summarize_coxreg`, `tabulate_survival_biomarkers`, `surv_time`, `surv_timepoint`, and `cfun_by_flag`.
 
 ### Miscellaneous
 * Updated README to include installation instructions for CRAN.
+* Began deprecation of `indent_mod` argument which is replaced by the `.indent_mods` argument in `summarize_num_patients` and `analyze_num_patients`.
 
 # tern 0.8.2
 

--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -27,10 +27,7 @@
 #'   Note that in that case the remaining occurrence levels in the table are sorted alphabetically.
 #' @param id (`string`)\cr subject variable name.
 #' @param is_event (`logical`)\cr `TRUE` if event, `FALSE` if time to event is censored.
-#' @param indent_mod (`count`)\cr it can be negative. Modifier for the default indent position for the
-#'   structure created by this function(subtable, content table, or row) and
-#'   all of that structure's children. Defaults to 0, which corresponds to the
-#'   unmodified default behavior.
+#' @param indent_mod `r lifecycle::badge("deprecated")` Please use the `.indent_mods` argument instead.
 #' @param labelstr (`character`)\cr label of the level of the parent split currently being summarized
 #'   (must be present as second argument in Content Row Functions).
 #' @param lyt (`layout`)\cr input layout where analyses will be added to.

--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -11,7 +11,8 @@
 #' @param .N_row (`count`)\cr column-wise N (column count) for the full column that is passed by `rtables`.
 #' @param .ref_group (`data.frame` or `vector`)\cr the data corresponding to the reference group.
 #' @param .stats (`character`)\cr statistics to select for the table.
-#' @param .indent_mods (named `integer`)\cr indent modifiers for the labels.
+#' @param .indent_mods (named `integer`)\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+#'   unmodified default behavior. Can be negative.
 #' @param .formats (named `character` or `list`)\cr formats for the statistics.
 #' @param .labels (named `character`)\cr labels for the statistics (without indent).
 #' @param .var (`string`)\cr single variable name that is passed by `rtables` when requested

--- a/R/compare_variables.R
+++ b/R/compare_variables.R
@@ -360,6 +360,9 @@ a_compare.logical <- make_afun(
 #' Constructor function which creates a combined formatted analysis function.
 #'
 #' @inheritParams argument_convention
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return Combined formatted analysis function for use in [compare_vars()].
 #'
@@ -473,6 +476,9 @@ create_afun_compare <- function(.stats = NULL,
 #'   and additional format arguments. This function is a wrapper for [rtables::analyze()].
 #'
 #' @param ... arguments passed to `s_compare()`.
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return
 #' * `compare_vars()` returns a layout object suitable for passing to further layouting functions,

--- a/R/h_biomarkers_subgroups.R
+++ b/R/h_biomarkers_subgroups.R
@@ -5,6 +5,7 @@
 #' Please see [h_tab_surv_one_biomarker()] and [h_tab_rsp_one_biomarker()], which use this function for examples.
 #' This function is a wrapper for [rtables::summarize_row_groups()].
 #'
+#' @inheritParams argument_convention
 #' @param df (`data.frame`)\cr results for a single biomarker.
 #' @param afuns (named `list` of `function`)\cr analysis functions.
 #' @param colvars (`list` with `vars` and `labels`)\cr variables to tabulate and their labels.

--- a/R/h_biomarkers_subgroups.R
+++ b/R/h_biomarkers_subgroups.R
@@ -14,7 +14,8 @@
 #' @export
 h_tab_one_biomarker <- function(df,
                                 afuns,
-                                colvars) {
+                                colvars,
+                                .indent_mods = 0L) {
   lyt <- basic_table()
 
   # Row split by row type - only keep the content rows here.
@@ -29,7 +30,8 @@ h_tab_one_biomarker <- function(df,
   lyt <- summarize_row_groups(
     lyt = lyt,
     var = "var_label",
-    cfun = afuns
+    cfun = afuns,
+    indent_mod = .indent_mods
   )
 
   # Split cols by the multiple variables to populate into columns.
@@ -56,7 +58,8 @@ h_tab_one_biomarker <- function(df,
       var = "var",
       labels_var = "var_label",
       nested = TRUE,
-      child_labels = "visible"
+      child_labels = "visible",
+      indent_mod = .indent_mods * 2
     )
 
     # Then analyze colvars for each subgroup.

--- a/R/h_response_biomarkers_subgroups.R
+++ b/R/h_response_biomarkers_subgroups.R
@@ -187,7 +187,8 @@ h_logistic_mult_cont_df <- function(variables,
 #'
 #' @export
 h_tab_rsp_one_biomarker <- function(df,
-                                    vars) {
+                                    vars,
+                                    .indent_mods = 0L) {
   afuns <- a_response_subgroups()[vars]
   colvars <- d_rsp_subgroups_colvars(
     vars,
@@ -197,6 +198,7 @@ h_tab_rsp_one_biomarker <- function(df,
   h_tab_one_biomarker(
     df = df,
     afuns = afuns,
-    colvars = colvars
+    colvars = colvars,
+    .indent_mods = .indent_mods
   )
 }

--- a/R/h_survival_biomarkers_subgroups.R
+++ b/R/h_survival_biomarkers_subgroups.R
@@ -196,7 +196,8 @@ h_coxreg_mult_cont_df <- function(variables,
 #' @export
 h_tab_surv_one_biomarker <- function(df,
                                      vars,
-                                     time_unit) {
+                                     time_unit,
+                                     .indent_mods = 0L) {
   afuns <- a_survival_subgroups()[vars]
   colvars <- d_survival_subgroups_colvars(
     vars,
@@ -207,6 +208,7 @@ h_tab_surv_one_biomarker <- function(df,
   h_tab_one_biomarker(
     df = df,
     afuns = afuns,
-    colvars = colvars
+    colvars = colvars,
+    .indent_mods = .indent_mods
   )
 }

--- a/R/kaplan_meier_plot.R
+++ b/R/kaplan_meier_plot.R
@@ -971,7 +971,7 @@ h_grob_tbl_at_risk <- function(data, annot_tbl, xlim) {
   annot_tbl <- expand.grid(
     time = seq(0, xlim, y_int),
     strata = unique(annot_tbl$strata)
-  ) %>% left_join(annot_tbl, by = c("time", "strata"))
+  ) %>% dplyr::left_join(annot_tbl, by = c("time", "strata"))
   annot_tbl[is.na(annot_tbl)] <- 0
   y_str_unit <- as.numeric(annot_tbl$strata)
   vp_table <- grid::plotViewport(margins = grid::unit(c(0, 0, 0, 0), "lines"))

--- a/R/logistic_regression.R
+++ b/R/logistic_regression.R
@@ -337,12 +337,12 @@ logistic_summary_by_flag <- function(flag_var, .indent_mods = NULL) {
   checkmate::assert_string(flag_var)
   function(lyt) {
     cfun_list <- list(
-      df = cfun_by_flag("df", flag_var, format = "xx.", indent_mod = .indent_mods),
-      estimate = cfun_by_flag("estimate", flag_var, format = "xx.xxx", indent_mod = .indent_mods),
-      std_error = cfun_by_flag("std_error", flag_var, format = "xx.xxx", indent_mod = .indent_mods),
-      odds_ratio = cfun_by_flag("odds_ratio", flag_var, format = ">999.99", indent_mod = .indent_mods),
-      ci = cfun_by_flag("ci", flag_var, format = format_extreme_values_ci(2L), indent_mod = .indent_mods),
-      pvalue = cfun_by_flag("pvalue", flag_var, format = "x.xxxx | (<0.0001)", indent_mod = .indent_mods)
+      df = cfun_by_flag("df", flag_var, format = "xx.", .indent_mods = .indent_mods),
+      estimate = cfun_by_flag("estimate", flag_var, format = "xx.xxx", .indent_mods = .indent_mods),
+      std_error = cfun_by_flag("std_error", flag_var, format = "xx.xxx", .indent_mods = .indent_mods),
+      odds_ratio = cfun_by_flag("odds_ratio", flag_var, format = ">999.99", .indent_mods = .indent_mods),
+      ci = cfun_by_flag("ci", flag_var, format = format_extreme_values_ci(2L), .indent_mods = .indent_mods),
+      pvalue = cfun_by_flag("pvalue", flag_var, format = "x.xxxx | (<0.0001)", .indent_mods = .indent_mods)
     )
     summarize_row_groups(
       lyt = lyt,

--- a/R/logistic_regression.R
+++ b/R/logistic_regression.R
@@ -326,6 +326,7 @@ logistic_regression_cols <- function(lyt,
 #' Constructor for content functions to be used in [`summarize_logistic()`] to summarize
 #' logistic regression results. This function is a wrapper for [rtables::summarize_row_groups()].
 #'
+#' @inheritParams argument_convention
 #' @param flag_var (`string`)\cr variable name identifying which row should be used in this
 #'   content function.
 #'

--- a/R/logistic_regression.R
+++ b/R/logistic_regression.R
@@ -78,13 +78,14 @@
 #' @export
 summarize_logistic <- function(lyt,
                                conf_level,
-                               drop_and_remove_str = "") {
+                               drop_and_remove_str = "",
+                               .indent_mods = NULL) {
   # checks
   checkmate::assert_string(drop_and_remove_str)
 
   sum_logistic_variable_test <- logistic_summary_by_flag("is_variable_summary")
-  sum_logistic_term_estimates <- logistic_summary_by_flag("is_term_summary")
-  sum_logistic_odds_ratios <- logistic_summary_by_flag("is_reference_summary")
+  sum_logistic_term_estimates <- logistic_summary_by_flag("is_term_summary", .indent_mods = .indent_mods)
+  sum_logistic_odds_ratios <- logistic_summary_by_flag("is_reference_summary", .indent_mods = .indent_mods)
   split_fun <- drop_and_remove_levels(drop_and_remove_str)
 
   lyt <- logistic_regression_cols(lyt, conf_level = conf_level)
@@ -331,16 +332,16 @@ logistic_regression_cols <- function(lyt,
 #' @return A content function.
 #'
 #' @export
-logistic_summary_by_flag <- function(flag_var) {
+logistic_summary_by_flag <- function(flag_var, .indent_mods = NULL) {
   checkmate::assert_string(flag_var)
   function(lyt) {
     cfun_list <- list(
-      df = cfun_by_flag("df", flag_var, format = "xx."),
-      estimate = cfun_by_flag("estimate", flag_var, format = "xx.xxx"),
-      std_error = cfun_by_flag("std_error", flag_var, format = "xx.xxx"),
-      odds_ratio = cfun_by_flag("odds_ratio", flag_var, format = ">999.99"),
-      ci = cfun_by_flag("ci", flag_var, format = format_extreme_values_ci(2L)),
-      pvalue = cfun_by_flag("pvalue", flag_var, format = "x.xxxx | (<0.0001)")
+      df = cfun_by_flag("df", flag_var, format = "xx.", indent_mod = .indent_mods),
+      estimate = cfun_by_flag("estimate", flag_var, format = "xx.xxx", indent_mod = .indent_mods),
+      std_error = cfun_by_flag("std_error", flag_var, format = "xx.xxx", indent_mod = .indent_mods),
+      odds_ratio = cfun_by_flag("odds_ratio", flag_var, format = ">999.99", indent_mod = .indent_mods),
+      ci = cfun_by_flag("ci", flag_var, format = format_extreme_values_ci(2L), indent_mod = .indent_mods),
+      pvalue = cfun_by_flag("pvalue", flag_var, format = "x.xxxx | (<0.0001)", indent_mod = .indent_mods)
     )
     summarize_row_groups(
       lyt = lyt,

--- a/R/response_biomarkers_subgroups.R
+++ b/R/response_biomarkers_subgroups.R
@@ -38,6 +38,17 @@
 #'   filter(PARAMCD == "BESRSPI") %>%
 #'   mutate(rsp = AVALC == "CR")
 #' formatters::var_labels(adrs_f) <- c(adrs_labels, "Response")
+#'
+#' df <- extract_rsp_biomarkers(
+#'   variables = list(
+#'     rsp = "rsp",
+#'     biomarkers = c("BMRKR1", "AGE"),
+#'     covariates = "SEX",
+#'     subgroups = "BMRKR2"
+#'   ),
+#'   data = adrs_f
+#' )
+#'
 #' \dontrun{
 #' ## Table with default columns.
 #' # df <- <need_data_input_to_work>
@@ -56,7 +67,8 @@
 #' @export
 #' @name response_biomarkers_subgroups
 tabulate_rsp_biomarkers <- function(df,
-                                    vars = c("n_tot", "n_rsp", "prop", "or", "ci", "pval")) {
+                                    vars = c("n_tot", "n_rsp", "prop", "or", "ci", "pval"),
+                                    .indent_mods = 0L) {
   checkmate::assert_data_frame(df)
   checkmate::assert_character(df$biomarker)
   checkmate::assert_character(df$biomarker_label)
@@ -66,7 +78,8 @@ tabulate_rsp_biomarkers <- function(df,
   tabs <- lapply(df_subs, FUN = function(df_sub) {
     tab_sub <- h_tab_rsp_one_biomarker(
       df = df_sub,
-      vars = vars
+      vars = vars,
+      .indent_mods = .indent_mods
     )
     # Insert label row as first row in table.
     label_at_path(tab_sub, path = row_paths(tab_sub)[[1]][1]) <- df_sub$biomarker_label[1]

--- a/R/response_biomarkers_subgroups.R
+++ b/R/response_biomarkers_subgroups.R
@@ -5,6 +5,7 @@
 #' Tabulate the estimated effects of multiple continuous biomarker variables
 #' on a binary response endpoint across population subgroups.
 #'
+#' @inheritParams argument_convention
 #' @param df (`data.frame`)\cr containing all analysis variables, as returned by
 #'   [extract_rsp_biomarkers()].
 #' @param vars (`character`)\cr the names of statistics to be reported among:
@@ -51,7 +52,6 @@
 #'
 #' \dontrun{
 #' ## Table with default columns.
-#' # df <- <need_data_input_to_work>
 #' tabulate_rsp_biomarkers(df)
 #'
 #' ## Table with a manually chosen set of columns: leave out "pval", reorder.

--- a/R/summarize_colvars.R
+++ b/R/summarize_colvars.R
@@ -8,6 +8,9 @@
 #'
 #' @inheritParams argument_convention
 #' @param ... arguments passed to `s_summary()`.
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return
 #' A layout object suitable for passing to further layouting functions, or to [rtables::build_table()].

--- a/R/summarize_coxreg.R
+++ b/R/summarize_coxreg.R
@@ -184,6 +184,7 @@ a_coxreg <- function(df,
                      .spl_context,
                      .stats,
                      .formats,
+                     .indent_mods = NULL,
                      na_level = "",
                      cache_env = NULL) {
   cov_no_arm <- !multivar && !"arm" %in% names(variables) && control$interaction # special case: univar no arm
@@ -244,7 +245,7 @@ a_coxreg <- function(df,
     names(var_vals)
   }
   in_rows(
-    .list = var_vals, .names = var_names, .labels = var_names,
+    .list = var_vals, .names = var_names, .labels = var_names, .indent_mods = .indent_mods,
     .formats = stats::setNames(rep(.formats, length(var_names)), var_names),
     .format_na_strs = stats::setNames(rep(na_level, length(var_names)), var_names)
   )
@@ -350,7 +351,7 @@ summarize_coxreg <- function(lyt,
       vars = rep(common_var, length(.stats)),
       varlabels = stat_labels,
       extra_args = list(
-        .stats = .stats, .formats = .formats, na_level = rep(na_level, length(.stats)),
+        .stats = .stats, .formats = .formats, .indent_mods = .indent_mods, na_level = rep(na_level, length(.stats)),
         cache_env = replicate(length(.stats), list(env))
       )
     )

--- a/R/summarize_num_patients.R
+++ b/R/summarize_num_patients.R
@@ -143,8 +143,14 @@ summarize_num_patients <- function(lyt,
                                      unique = "Number of patients with at least one event",
                                      nonunique = "Number of events"
                                    ),
-                                   indent_mod = 0L,
+                                   indent_mod = lifecycle::deprecated(),
+                                   .indent_mods = 0L,
                                    ...) {
+  if (lifecycle::is_present(indent_mod)) {
+    lifecycle::deprecate_warn("0.8.2", "summarize_num_patients(indent_mod)", "summarize_num_patients(.indent_mods)")
+    .indent_mods <- indent_mod
+  }
+
   if (is.null(.stats)) .stats <- c("unique", "nonunique", "unique_count")
   if (length(.labels) > length(.stats)) .labels <- .labels[names(.labels) %in% .stats]
 
@@ -160,7 +166,7 @@ summarize_num_patients <- function(lyt,
     var = var,
     cfun = cfun,
     extra_args = list(...),
-    indent_mod = indent_mod
+    indent_mod = .indent_mods
   )
 }
 
@@ -204,8 +210,14 @@ analyze_num_patients <- function(lyt,
                                    nonunique = "Number of events"
                                  ),
                                  show_labels = c("default", "visible", "hidden"),
-                                 indent_mod = 0L,
+                                 indent_mod = lifecycle::deprecated(),
+                                 .indent_mods = 0L,
                                  ...) {
+  if (lifecycle::is_present(indent_mod)) {
+    lifecycle::deprecate_warn("0.8.2", "analyze_num_patients(indent_mod)", "analyze_num_patients(.indent_mods)")
+    .indent_mods <- indent_mod
+  }
+
   if (is.null(.stats)) .stats <- c("unique", "nonunique", "unique_count")
   if (length(.labels) > length(.stats)) .labels <- .labels[names(.labels) %in% .stats]
 
@@ -222,6 +234,6 @@ analyze_num_patients <- function(lyt,
     vars = vars,
     extra_args = list(...),
     show_labels = show_labels,
-    indent_mod = indent_mod
+    indent_mod = .indent_mods
   )
 }

--- a/R/summarize_variables.R
+++ b/R/summarize_variables.R
@@ -560,6 +560,9 @@ a_summary.logical <- make_afun(
 #' Constructor function which creates a combined formatted analysis function.
 #'
 #' @inheritParams argument_convention
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return Combined formatted analysis function for use in [summarize_vars()].
 #'
@@ -660,6 +663,9 @@ create_afun_summary <- function(.stats, .formats, .labels, .indent_mods) {
 #'   and additional format arguments. This function is a wrapper for [rtables::analyze()].
 #'
 #' @param ... arguments passed to `s_summary()`.
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return
 #' * `summarize_vars()` returns a layout object suitable for passing to further layouting functions,

--- a/R/survival_biomarkers_subgroups.R
+++ b/R/survival_biomarkers_subgroups.R
@@ -208,7 +208,8 @@ extract_survival_biomarkers <- function(variables,
 #' @export
 tabulate_survival_biomarkers <- function(df,
                                          vars = c("n_tot", "n_tot_events", "median", "hr", "ci", "pval"),
-                                         time_unit = NULL) {
+                                         time_unit = NULL,
+                                         .indent_mods = 0L) {
   checkmate::assert_data_frame(df)
   checkmate::assert_character(df$biomarker)
   checkmate::assert_character(df$biomarker_label)
@@ -219,7 +220,8 @@ tabulate_survival_biomarkers <- function(df,
     tab_sub <- h_tab_surv_one_biomarker(
       df = df_sub,
       vars = vars,
-      time_unit = time_unit
+      time_unit = time_unit,
+      .indent_mods = .indent_mods
     )
     # Insert label row as first row in table.
     label_at_path(tab_sub, path = row_paths(tab_sub)[[1]][1]) <- df_sub$biomarker_label[1]

--- a/R/survival_time.R
+++ b/R/survival_time.R
@@ -97,14 +97,6 @@ s_surv_time <- function(df,
 #' @keywords internal
 a_surv_time <- make_afun(
   s_surv_time,
-  .indent_mods = c(
-    "median" = 0L,
-    "median_ci" = 1L,
-    "quantiles" = 0L,
-    "range_censor" = 0L,
-    "range_event" = 0L,
-    "range" = 0L
-  ),
   .formats = c(
     "median" = "xx.x",
     "median_ci" = "(xx.x, xx.x)",
@@ -117,6 +109,10 @@ a_surv_time <- make_afun(
 
 #' @describeIn survival_time Layout-creating function which can take statistics function arguments
 #'   and additional format arguments. This function is a wrapper for [rtables::analyze()].
+#'
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return
 #' * `surv_time()` returns a layout object suitable for passing to further layouting functions,
@@ -144,13 +140,16 @@ surv_time <- function(lyt,
                       .stats = c("median", "median_ci", "quantiles", "range_censor", "range_event"),
                       .formats = NULL,
                       .labels = NULL,
-                      .indent_mods = NULL) {
+                      .indent_mods = c(
+                        "median" = 0L, "median_ci" = 1L, "quantiles" = 0L,
+                        "range_censor" = 0L, "range_event" = 0L, "range" = 0L
+                      )) {
   afun <- make_afun(
     a_surv_time,
     .stats = .stats,
     .formats = .formats,
     .labels = .labels,
-    .indent_mods = .indent_mods
+    .indent_mods = extract_by_name(.indent_mods, .stats)
   )
   analyze(
     lyt,

--- a/R/survival_timepoint.R
+++ b/R/survival_timepoint.R
@@ -221,6 +221,9 @@ a_surv_timepoint_diff <- make_afun(
 #'   `surv_diff` (difference in survival with the control) or `both`.
 #' @param table_names_suffix (`string`)\cr optional suffix for the `table_names` used for the `rtables` to
 #'   avoid warnings from duplicate table names.
+#' @param .indent_mods (named `vector` of `integer`)\cr indent modifiers for the labels. Each element of the vector
+#'   should be a name-value pair with name corresponding to a statistic specified in `.stats` and value the indentation
+#'   for that statistic's row label.
 #'
 #' @return
 #' * `surv_timepoint()` returns a layout object suitable for passing to further layouting functions,

--- a/R/survival_timepoint.R
+++ b/R/survival_timepoint.R
@@ -202,11 +202,6 @@ s_surv_timepoint_diff <- function(df,
 #' @keywords internal
 a_surv_timepoint_diff <- make_afun(
   s_surv_timepoint_diff,
-  .indent_mods = c(
-    rate_diff = 1L,
-    rate_diff_ci = 2L,
-    ztest_pval = 2L
-  ),
   .formats = c(
     rate_diff = "xx.xx",
     rate_diff_ci = "(xx.xx, xx.xx)",
@@ -285,7 +280,11 @@ surv_timepoint <- function(lyt,
                            ),
                            .formats = NULL,
                            .labels = NULL,
-                           .indent_mods = NULL) {
+                           .indent_mods = if (method == "both") {
+                             c(rate_diff = 1L, rate_diff_ci = 2L, ztest_pval = 2L)
+                           } else {
+                             c(rate_diff_ci = 1L, ztest_pval = 1L)
+                           }) {
   method <- match.arg(method)
   checkmate::assert_string(table_names_suffix)
 

--- a/R/utils_rtables.R
+++ b/R/utils_rtables.R
@@ -74,14 +74,14 @@ unlist_and_blank_na <- function(x) {
 cfun_by_flag <- function(analysis_var,
                          flag_var,
                          format = "xx",
-                         indent_mod = NULL) {
+                         .indent_mods = NULL) {
   checkmate::assert_string(analysis_var)
   checkmate::assert_string(flag_var)
   function(df, labelstr) {
     row_index <- which(df[[flag_var]])
     x <- unlist_and_blank_na(df[[analysis_var]][row_index])
     formatters::with_label(
-      rcell(x, format = format, indent_mod = indent_mod),
+      rcell(x, format = format, indent_mod = .indent_mods),
       labelstr
     )
   }

--- a/R/utils_rtables.R
+++ b/R/utils_rtables.R
@@ -73,14 +73,15 @@ unlist_and_blank_na <- function(x) {
 #' @keywords internal
 cfun_by_flag <- function(analysis_var,
                          flag_var,
-                         format = "xx") {
+                         format = "xx",
+                         indent_mod = NULL) {
   checkmate::assert_string(analysis_var)
   checkmate::assert_string(flag_var)
   function(df, labelstr) {
     row_index <- which(df[[flag_var]])
     x <- unlist_and_blank_na(df[[analysis_var]][row_index])
     formatters::with_label(
-      rcell(x, format = format),
+      rcell(x, format = format, indent_mod = indent_mod),
       labelstr
     )
   }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -49,6 +49,7 @@ coercible
 colvars
 coull
 coxph
+coxreg
 doi
 efron
 funder

--- a/man/abnormal.Rd
+++ b/man/abnormal.Rd
@@ -62,7 +62,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/abnormal_by_baseline.Rd
+++ b/man/abnormal_by_baseline.Rd
@@ -61,7 +61,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/abnormal_by_marked.Rd
+++ b/man/abnormal_by_marked.Rd
@@ -57,7 +57,8 @@ and last or replicated.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/abnormal_by_worst_grade.Rd
+++ b/man/abnormal_by_worst_grade.Rd
@@ -52,7 +52,8 @@ that is passed by \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/abnormal_by_worst_grade_worsen.Rd
+++ b/man/abnormal_by_worst_grade_worsen.Rd
@@ -56,7 +56,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/analyze_vars_in_cols.Rd
+++ b/man/analyze_vars_in_cols.Rd
@@ -44,7 +44,8 @@ to define row labels. This behavior is not supported as we never need to overloa
 This option allows you to add multiple instances of this functions, also in a nested fashion,
 without adding more splits. This split must happen only one time on a single layout.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{nested}{(\code{flag})\cr whether this layout instruction be applied within the existing layout structure \emph{if
 possible} (\code{TRUE}, the default) or as a new top-level element (\code{FALSE}). Ignored if it would nest a split

--- a/man/argument_convention.Rd
+++ b/man/argument_convention.Rd
@@ -19,7 +19,8 @@
 
 \item{.stats}{(\code{character})\cr statistics to select for the table.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{.formats}{(named \code{character} or \code{list})\cr formats for the statistics.}
 

--- a/man/argument_convention.Rd
+++ b/man/argument_convention.Rd
@@ -48,10 +48,7 @@ Note that in that case the remaining occurrence levels in the table are sorted a
 
 \item{is_event}{(\code{logical})\cr \code{TRUE} if event, \code{FALSE} if time to event is censored.}
 
-\item{indent_mod}{(\code{count})\cr it can be negative. Modifier for the default indent position for the
-structure created by this function(subtable, content table, or row) and
-all of that structure's children. Defaults to 0, which corresponds to the
-unmodified default behavior.}
+\item{indent_mod}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use the \code{.indent_mods} argument instead.}
 
 \item{labelstr}{(\code{character})\cr label of the level of the parent split currently being summarized
 (must be present as second argument in Content Row Functions).}

--- a/man/cfun_by_flag.Rd
+++ b/man/cfun_by_flag.Rd
@@ -4,7 +4,7 @@
 \alias{cfun_by_flag}
 \title{Constructor for Content Functions given Data Frame with Flag Input}
 \usage{
-cfun_by_flag(analysis_var, flag_var, format = "xx", indent_mod = NULL)
+cfun_by_flag(analysis_var, flag_var, format = "xx", .indent_mods = NULL)
 }
 \arguments{
 \item{analysis_var}{(\code{string})\cr variable name for the column containing values to be returned by the

--- a/man/cfun_by_flag.Rd
+++ b/man/cfun_by_flag.Rd
@@ -4,7 +4,7 @@
 \alias{cfun_by_flag}
 \title{Constructor for Content Functions given Data Frame with Flag Input}
 \usage{
-cfun_by_flag(analysis_var, flag_var, format = "xx")
+cfun_by_flag(analysis_var, flag_var, format = "xx", indent_mod = NULL)
 }
 \arguments{
 \item{analysis_var}{(\code{string})\cr variable name for the column containing values to be returned by the

--- a/man/compare_variables.Rd
+++ b/man/compare_variables.Rd
@@ -128,7 +128,9 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 \itemize{

--- a/man/count_cumulative.Rd
+++ b/man/count_cumulative.Rd
@@ -68,7 +68,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/count_missed_doses.Rd
+++ b/man/count_missed_doses.Rd
@@ -53,7 +53,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/count_occurrences.Rd
+++ b/man/count_occurrences.Rd
@@ -80,7 +80,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/count_occurrences_by_grade.Rd
+++ b/man/count_occurrences_by_grade.Rd
@@ -84,7 +84,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.formats}{(named \code{character} or \code{list})\cr formats for the statistics.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 }

--- a/man/count_patients_with_event.Rd
+++ b/man/count_patients_with_event.Rd
@@ -73,7 +73,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/count_patients_with_flags.Rd
+++ b/man/count_patients_with_flags.Rd
@@ -74,7 +74,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.formats}{(named \code{character} or \code{list})\cr formats for the statistics.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/count_values_funs.Rd
+++ b/man/count_values_funs.Rd
@@ -80,7 +80,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/cox_regression.Rd
+++ b/man/cox_regression.Rd
@@ -89,7 +89,8 @@ that is passed by \code{rtables}.}
 
 \item{.formats}{(named \code{character} or \code{list})\cr formats for the statistics.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{na_level}{(\code{string})\cr custom string to replace all \code{NA} values with. Defaults to \code{""}.}
 

--- a/man/cox_regression.Rd
+++ b/man/cox_regression.Rd
@@ -21,6 +21,7 @@ a_coxreg(
   .spl_context,
   .stats,
   .formats,
+  .indent_mods = NULL,
   na_level = "",
   cache_env = NULL
 )
@@ -88,6 +89,8 @@ that is passed by \code{rtables}.}
 
 \item{.formats}{(named \code{character} or \code{list})\cr formats for the statistics.}
 
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+
 \item{na_level}{(\code{string})\cr custom string to replace all \code{NA} values with. Defaults to \code{""}.}
 
 \item{cache_env}{(\code{environment})\cr an environment object used to cache the regression model in order to
@@ -97,8 +100,6 @@ avoid repeatedly fitting the same model for every row in the table. Defaults to 
 
 \item{common_var}{(\code{character})\cr the name of a factor variable in the dataset which takes the same value
 for all rows. This should be created during pre-processing if no such variable currently exists.}
-
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 
 \item{.section_div}{(\code{character})\cr string which should be repeated as a section divider between sections.
 Defaults to \code{NA} for no section divider. If a vector of two strings are given, the first will be used between

--- a/man/create_afun_compare.Rd
+++ b/man/create_afun_compare.Rd
@@ -18,7 +18,9 @@ create_afun_compare(
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 Combined formatted analysis function for use in \code{\link[=compare_vars]{compare_vars()}}.

--- a/man/create_afun_summary.Rd
+++ b/man/create_afun_summary.Rd
@@ -13,7 +13,9 @@ create_afun_summary(.stats, .formats, .labels, .indent_mods)
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 Combined formatted analysis function for use in \code{\link[=summarize_vars]{summarize_vars()}}.

--- a/man/estimate_multinomial_rsp.Rd
+++ b/man/estimate_multinomial_rsp.Rd
@@ -47,7 +47,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/estimate_proportions.Rd
+++ b/man/estimate_proportions.Rd
@@ -88,7 +88,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/h_response_biomarkers_subgroups.Rd
+++ b/man/h_response_biomarkers_subgroups.Rd
@@ -39,7 +39,8 @@ see the example).}
 Note, the statistics \code{n_tot}, \code{or} and \code{ci} are required.
 }}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/h_response_biomarkers_subgroups.Rd
+++ b/man/h_response_biomarkers_subgroups.Rd
@@ -11,7 +11,7 @@ h_rsp_to_logistic_variables(variables, biomarker)
 
 h_logistic_mult_cont_df(variables, data, control = control_logistic())
 
-h_tab_rsp_one_biomarker(df, vars)
+h_tab_rsp_one_biomarker(df, vars, .indent_mods = 0L)
 }
 \arguments{
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
@@ -38,6 +38,8 @@ see the example).}
 \item \code{pval}: p-value of the effect.
 Note, the statistics \code{n_tot}, \code{or} and \code{ci} are required.
 }}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 \itemize{

--- a/man/h_survival_biomarkers_subgroups.Rd
+++ b/man/h_survival_biomarkers_subgroups.Rd
@@ -11,7 +11,7 @@ h_surv_to_coxreg_variables(variables, biomarker)
 
 h_coxreg_mult_cont_df(variables, data, control = control_coxreg())
 
-h_tab_surv_one_biomarker(df, vars, time_unit)
+h_tab_surv_one_biomarker(df, vars, time_unit, .indent_mods = 0L)
 }
 \arguments{
 \item{variables}{(named \code{list} of \code{string})\cr list of additional analysis variables.}
@@ -39,6 +39,8 @@ Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as bot
 }}
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips displaying unit.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 \itemize{

--- a/man/h_survival_biomarkers_subgroups.Rd
+++ b/man/h_survival_biomarkers_subgroups.Rd
@@ -40,7 +40,8 @@ Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as bot
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips displaying unit.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/h_tab_one_biomarker.Rd
+++ b/man/h_tab_one_biomarker.Rd
@@ -4,7 +4,7 @@
 \alias{h_tab_one_biomarker}
 \title{Helper Function for Tabulation of a Single Biomarker Result}
 \usage{
-h_tab_one_biomarker(df, afuns, colvars)
+h_tab_one_biomarker(df, afuns, colvars, .indent_mods = 0L)
 }
 \arguments{
 \item{df}{(\code{data.frame})\cr results for a single biomarker.}

--- a/man/h_tab_one_biomarker.Rd
+++ b/man/h_tab_one_biomarker.Rd
@@ -12,6 +12,8 @@ h_tab_one_biomarker(df, afuns, colvars, .indent_mods = 0L)
 \item{afuns}{(named \code{list} of \code{function})\cr analysis functions.}
 
 \item{colvars}{(\code{list} with \code{vars} and \code{labels})\cr variables to tabulate and their labels.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 An \code{rtables} table object with statistics in columns.

--- a/man/h_tab_one_biomarker.Rd
+++ b/man/h_tab_one_biomarker.Rd
@@ -13,7 +13,8 @@ h_tab_one_biomarker(df, afuns, colvars, .indent_mods = 0L)
 
 \item{colvars}{(\code{list} with \code{vars} and \code{labels})\cr variables to tabulate and their labels.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 An \code{rtables} table object with statistics in columns.

--- a/man/incidence_rate.Rd
+++ b/man/incidence_rate.Rd
@@ -73,7 +73,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{person_years}{(\code{numeric})\cr total person-years at risk.}
 

--- a/man/logistic_summary_by_flag.Rd
+++ b/man/logistic_summary_by_flag.Rd
@@ -10,7 +10,8 @@ logistic_summary_by_flag(flag_var, .indent_mods = NULL)
 \item{flag_var}{(\code{string})\cr variable name identifying which row should be used in this
 content function.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 A content function.

--- a/man/logistic_summary_by_flag.Rd
+++ b/man/logistic_summary_by_flag.Rd
@@ -9,6 +9,8 @@ logistic_summary_by_flag(flag_var, .indent_mods = NULL)
 \arguments{
 \item{flag_var}{(\code{string})\cr variable name identifying which row should be used in this
 content function.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 A content function.

--- a/man/logistic_summary_by_flag.Rd
+++ b/man/logistic_summary_by_flag.Rd
@@ -4,7 +4,7 @@
 \alias{logistic_summary_by_flag}
 \title{Logistic Regression Summary Table Constructor Function}
 \usage{
-logistic_summary_by_flag(flag_var)
+logistic_summary_by_flag(flag_var, .indent_mods = NULL)
 }
 \arguments{
 \item{flag_var}{(\code{string})\cr variable name identifying which row should be used in this

--- a/man/odds_ratio.Rd
+++ b/man/odds_ratio.Rd
@@ -77,7 +77,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/prop_diff.Rd
+++ b/man/prop_diff.Rd
@@ -82,7 +82,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/prop_diff_test.Rd
+++ b/man/prop_diff_test.Rd
@@ -72,7 +72,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{tbl}{(\code{matrix})\cr matrix with two groups in rows and the binary response (\code{TRUE}/\code{FALSE}) in columns.}
 }

--- a/man/response_biomarkers_subgroups.Rd
+++ b/man/response_biomarkers_subgroups.Rd
@@ -25,6 +25,8 @@ tabulate_rsp_biomarkers(
 \item \code{pval}: p-value of the effect.
 Note, the statistics \code{n_tot}, \code{or} and \code{ci} are required.
 }}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 An \code{rtables} table summarizing biomarker effects on binary response by subgroup.
@@ -68,7 +70,6 @@ df <- extract_rsp_biomarkers(
 
 \dontrun{
 ## Table with default columns.
-# df <- <need_data_input_to_work>
 tabulate_rsp_biomarkers(df)
 
 ## Table with a manually chosen set of columns: leave out "pval", reorder.

--- a/man/response_biomarkers_subgroups.Rd
+++ b/man/response_biomarkers_subgroups.Rd
@@ -26,7 +26,8 @@ tabulate_rsp_biomarkers(
 Note, the statistics \code{n_tot}, \code{or} and \code{ci} are required.
 }}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 An \code{rtables} table summarizing biomarker effects on binary response by subgroup.

--- a/man/response_biomarkers_subgroups.Rd
+++ b/man/response_biomarkers_subgroups.Rd
@@ -7,7 +7,8 @@
 \usage{
 tabulate_rsp_biomarkers(
   df,
-  vars = c("n_tot", "n_rsp", "prop", "or", "ci", "pval")
+  vars = c("n_tot", "n_rsp", "prop", "or", "ci", "pval"),
+  .indent_mods = 0L
 )
 }
 \arguments{
@@ -54,6 +55,17 @@ adrs_f <- adrs \%>\%
   filter(PARAMCD == "BESRSPI") \%>\%
   mutate(rsp = AVALC == "CR")
 formatters::var_labels(adrs_f) <- c(adrs_labels, "Response")
+
+df <- extract_rsp_biomarkers(
+  variables = list(
+    rsp = "rsp",
+    biomarkers = c("BMRKR1", "AGE"),
+    covariates = "SEX",
+    subgroups = "BMRKR2"
+  ),
+  data = adrs_f
+)
+
 \dontrun{
 ## Table with default columns.
 # df <- <need_data_input_to_work>

--- a/man/summarize_ancova.Rd
+++ b/man/summarize_ancova.Rd
@@ -86,7 +86,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/summarize_change.Rd
+++ b/man/summarize_change.Rd
@@ -46,7 +46,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/summarize_colvars.Rd
+++ b/man/summarize_colvars.Rd
@@ -24,7 +24,9 @@ summarize_colvars(
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 A layout object suitable for passing to further layouting functions, or to \code{\link[rtables:build_table]{rtables::build_table()}}.

--- a/man/summarize_glm_count.Rd
+++ b/man/summarize_glm_count.Rd
@@ -82,7 +82,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/summarize_logistic.Rd
+++ b/man/summarize_logistic.Rd
@@ -4,7 +4,12 @@
 \alias{summarize_logistic}
 \title{Multivariate Logistic Regression Table}
 \usage{
-summarize_logistic(lyt, conf_level, drop_and_remove_str = "")
+summarize_logistic(
+  lyt,
+  conf_level,
+  drop_and_remove_str = "",
+  .indent_mods = NULL
+)
 }
 \arguments{
 \item{lyt}{(\code{layout})\cr input layout where analyses will be added to.}
@@ -12,6 +17,8 @@ summarize_logistic(lyt, conf_level, drop_and_remove_str = "")
 \item{conf_level}{(\code{proportion})\cr confidence level of the interval.}
 
 \item{drop_and_remove_str}{(\code{character})\cr string to be dropped and removed.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 A layout object suitable for passing to further layouting functions, or to \code{\link[rtables:build_table]{rtables::build_table()}}.

--- a/man/summarize_logistic.Rd
+++ b/man/summarize_logistic.Rd
@@ -18,7 +18,8 @@ summarize_logistic(
 
 \item{drop_and_remove_str}{(\code{character})\cr string to be dropped and removed.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 A layout object suitable for passing to further layouting functions, or to \code{\link[rtables:build_table]{rtables::build_table()}}.

--- a/man/summarize_num_patients.Rd
+++ b/man/summarize_num_patients.Rd
@@ -82,7 +82,8 @@ by a statistics function.}
 
 \item{indent_mod}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use the \code{.indent_mods} argument instead.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{...}{additional arguments for the lower level functions.}
 

--- a/man/summarize_num_patients.Rd
+++ b/man/summarize_num_patients.Rd
@@ -32,7 +32,8 @@ summarize_num_patients(
   .formats = NULL,
   .labels = c(unique = "Number of patients with at least one event", nonunique =
     "Number of events"),
-  indent_mod = 0L,
+  indent_mod = lifecycle::deprecated(),
+  .indent_mods = 0L,
   ...
 )
 
@@ -44,7 +45,8 @@ analyze_num_patients(
   .labels = c(unique = "Number of patients with at least one event", nonunique =
     "Number of events"),
   show_labels = c("default", "visible", "hidden"),
-  indent_mod = 0L,
+  indent_mod = lifecycle::deprecated(),
+  .indent_mods = 0L,
   ...
 )
 }
@@ -78,10 +80,9 @@ by a statistics function.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{indent_mod}{(\code{count})\cr it can be negative. Modifier for the default indent position for the
-structure created by this function(subtable, content table, or row) and
-all of that structure's children. Defaults to 0, which corresponds to the
-unmodified default behavior.}
+\item{indent_mod}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use the \code{.indent_mods} argument instead.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 
 \item{...}{additional arguments for the lower level functions.}
 

--- a/man/summarize_patients_exposure_in_cols.Rd
+++ b/man/summarize_patients_exposure_in_cols.Rd
@@ -77,7 +77,8 @@ by a statistics function.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 
 \item{col_split}{(\code{flag})\cr whether the columns should be split. Set to \code{FALSE} when the required
 column split has been done already earlier in the layout pipe.}

--- a/man/summarize_variables.Rd
+++ b/man/summarize_variables.Rd
@@ -181,7 +181,9 @@ defined by this split instruction, or \code{NA_character_} (the default) for no 
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 \itemize{

--- a/man/survival_biomarkers_subgroups.Rd
+++ b/man/survival_biomarkers_subgroups.Rd
@@ -8,7 +8,8 @@
 tabulate_survival_biomarkers(
   df,
   vars = c("n_tot", "n_tot_events", "median", "hr", "ci", "pval"),
-  time_unit = NULL
+  time_unit = NULL,
+  .indent_mods = 0L
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as bot
 }}
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips displaying unit.}
+
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
 }
 \value{
 An \code{rtables} table summarizing biomarker effects on survival by subgroup.

--- a/man/survival_biomarkers_subgroups.Rd
+++ b/man/survival_biomarkers_subgroups.Rd
@@ -29,7 +29,8 @@ Note, one of the statistics \code{n_tot} and \code{n_tot_events}, as well as bot
 
 \item{time_unit}{(\code{string})\cr label with unit of median survival time. Default \code{NULL} skips displaying unit.}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 An \code{rtables} table summarizing biomarker effects on survival by subgroup.

--- a/man/survival_coxph_pairwise.Rd
+++ b/man/survival_coxph_pairwise.Rd
@@ -83,7 +83,8 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels. Defaults to 0, which corresponds to the
+unmodified default behavior. Can be negative.}
 }
 \value{
 \itemize{

--- a/man/survival_time.Rd
+++ b/man/survival_time.Rd
@@ -20,7 +20,8 @@ surv_time(
   .stats = c("median", "median_ci", "quantiles", "range_censor", "range_event"),
   .formats = NULL,
   .labels = NULL,
-  .indent_mods = NULL
+  .indent_mods = c(median = 0L, median_ci = 1L, quantiles = 0L, range_censor = 0L,
+    range_event = 0L, range = 0L)
 )
 }
 \arguments{
@@ -57,7 +58,9 @@ to avoid warnings from \code{rtables}.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 \itemize{

--- a/man/survival_timepoint.Rd
+++ b/man/survival_timepoint.Rd
@@ -105,7 +105,9 @@ avoid warnings from duplicate table names.}
 
 \item{.labels}{(named \code{character})\cr labels for the statistics (without indent).}
 
-\item{.indent_mods}{(named \code{integer})\cr indent modifiers for the labels.}
+\item{.indent_mods}{(named \code{vector} of \code{integer})\cr indent modifiers for the labels. Each element of the vector
+should be a name-value pair with name corresponding to a statistic specified in \code{.stats} and value the indentation
+for that statistic's row label.}
 }
 \value{
 \itemize{

--- a/man/survival_timepoint.Rd
+++ b/man/survival_timepoint.Rd
@@ -57,7 +57,12 @@ surv_timepoint(
     "ztest_pval"),
   .formats = NULL,
   .labels = NULL,
-  .indent_mods = NULL
+  .indent_mods = if (method == "both") {
+     c(rate_diff = 1L, rate_diff_ci = 2L,
+    ztest_pval = 2L)
+ } else {
+     c(rate_diff_ci = 1L, ztest_pval = 1L)
+ }
 )
 }
 \arguments{


### PR DESCRIPTION
Closes #941 

Indentation implemented in all functions except `tabulate_survival_subgroups` and `tabulate_rsp_subgroups`.