### PR TITLE
Remove "baseline status" text from abnormal by baseline labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Added explicit zero counts to `g_km` plot "at risk" annotation tables.
 * Added a flag for total level split in `analyze_patients_exposure_in_cols`.
 * Implemented `.indent_mods` argument in functions `h_tab_one_biomarker`, `h_tab_rsp_one_biomarker`, `h_tab_surv_one_biomarker`, `summarize_logistic`, `logistic_summary_by_flag`, `tabulate_rsp_biomarkers`, a_coxreg, `summarize_coxreg`, `tabulate_survival_biomarkers`, `surv_time`, `surv_timepoint`, and `cfun_by_flag`.
+* Removed "baseline status" text from `d_count_abnormal_by_baseline` labels.
 
 ### Bug Fixes
 * Fixed bug in `split_text_grob` preventing titles and footnotes from being properly formatted and printed by `decorate_grob`.

--- a/R/abnormal_by_baseline.R
+++ b/R/abnormal_by_baseline.R
@@ -45,8 +45,8 @@ NULL
 #' @export
 d_count_abnormal_by_baseline <- function(abnormal) {
   null_name <- paste0(toupper(substr(abnormal, 1, 1)), tolower(substring(abnormal, 2)))
-  not_abn_name <- paste("Not", tolower(abnormal), "baseline status")
-  abn_name <- paste(null_name, "baseline status")
+  not_abn_name <- paste("Not", tolower(abnormal))
+  abn_name <- null_name
   total_name <- "Total"
 
   list(

--- a/R/abnormal_by_baseline.R
+++ b/R/abnormal_by_baseline.R
@@ -44,9 +44,8 @@ NULL
 #'
 #' @export
 d_count_abnormal_by_baseline <- function(abnormal) {
-  null_name <- paste0(toupper(substr(abnormal, 1, 1)), tolower(substring(abnormal, 2)))
   not_abn_name <- paste("Not", tolower(abnormal))
-  abn_name <- null_name
+  abn_name <- paste0(toupper(substr(abnormal, 1, 1)), tolower(substring(abnormal, 2)))
   total_name <- "Total"
 
   list(

--- a/tests/testthat/_snaps/abnormal_by_baseline.md
+++ b/tests/testthat/_snaps/abnormal_by_baseline.md
@@ -8,13 +8,13 @@
         num denom 
           1     3 
       attr(,"label")
-      [1] "Not low baseline status"
+      [1] "Not low"
       
       $fraction$abnormal
         num denom 
           0     1 
       attr(,"label")
-      [1] "Low baseline status"
+      [1] "Low"
       
       $fraction$total
         num denom 
@@ -34,13 +34,13 @@
         num denom 
           1     3 
       attr(,"label")
-      [1] "Not high baseline status"
+      [1] "Not high"
       
       $fraction$abnormal
         num denom 
           1     1 
       attr(,"label")
-      [1] "High baseline status"
+      [1] "High"
       
       $fraction$total
         num denom 
@@ -60,13 +60,13 @@
         num denom 
           2     5 
       attr(,"label")
-      [1] "Not low baseline status"
+      [1] "Not low"
       
       $fraction$abnormal
         num denom 
           0     1 
       attr(,"label")
-      [1] "Low baseline status"
+      [1] "Low"
       
       $fraction$total
         num denom 
@@ -86,13 +86,13 @@
         num denom 
           1     5 
       attr(,"label")
-      [1] "Not high baseline status"
+      [1] "Not high"
       
       $fraction$abnormal
         num denom 
           0     1 
       attr(,"label")
-      [1] "High baseline status"
+      [1] "High"
       
       $fraction$total
         num denom 
@@ -112,13 +112,13 @@
         num denom 
           2     4 
       attr(,"label")
-      [1] "Not low baseline status"
+      [1] "Not low"
       
       $fraction$abnormal
         num denom 
           0     1 
       attr(,"label")
-      [1] "Low baseline status"
+      [1] "Low"
       
       $fraction$total
         num denom 
@@ -133,30 +133,30 @@
     Code
       res
     Output
-                                     all obs  
-      ————————————————————————————————————————
-      Low                                     
-        Not low baseline status    1/3 (33.3%)
-        Low baseline status            0/1    
-        Total                       1/4 (25%) 
-      High                                    
-        Not high baseline status    1/2 (50%) 
-        High baseline status        1/2 (50%) 
-        Total                       2/4 (50%) 
+                     all obs  
+      ————————————————————————
+      Low                     
+        Not low    1/3 (33.3%)
+        Low            0/1    
+        Total       1/4 (25%) 
+      High                    
+        Not high    1/2 (50%) 
+        High        1/2 (50%) 
+        Total       2/4 (50%) 
 
 # count_abnormal_by_baseline works with custom arguments
 
     Code
       res
     Output
-                                   all obs
-      ————————————————————————————————————
-      Low                                 
-        Not low baseline status     1 / 3 
-        Low baseline status         0 / 1 
-        Total                       1 / 4 
-      High                                
-        Not high baseline status    1 / 2 
-        High baseline status        1 / 2 
-        Total                       2 / 4 
+                   all obs
+      ————————————————————
+      Low                 
+        Not low     1 / 3 
+        Low         0 / 1 
+        Total       1 / 4 
+      High                
+        Not high    1 / 2 
+        High        1 / 2 
+        Total       2 / 4 
 


### PR DESCRIPTION
I could not find a reason why this text was initially included so I think we are fine to remove it.

Closes #947 