### PR TITLE
add `--as-cran` to local proj checks

### DIFF
--- a/tern.Rproj
+++ b/tern.Rproj
@@ -19,4 +19,5 @@ LineEndingConversion: Posix
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
I think this is the minimum that can be done. I am not sure if CI does check it already with `--as-cran` but, eventually, it is a fast fix, right @cicdguy?
Fixes #887
