### PR TITLE
tlg-catalog no longer contains staged.dependencies.

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -54,6 +54,3 @@ downstream_repos:
   insightsengineering/tern.rbmi:
     repo: insightsengineering/tern.rbmi
     host: https://github.com
-  insightsengineering/tlg-catalog:
-    repo: insightsengineering/tlg-catalog
-    host: https://github.com

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -54,3 +54,6 @@ downstream_repos:
   insightsengineering/tern.rbmi:
     repo: insightsengineering/tern.rbmi
     host: https://github.com
+  insightsengineering/tlg-catalog:
+    repo: insightsengineering/tlg-catalog/package
+    host: https://github.com


### PR DESCRIPTION
To fix following

```r
staged.dependencies::dependency_table(
  project = "insightsengineering/tern@https://github.com",
  project_type = "repo@host",
  ref = "main",
  verbose = 1
)
```

This branch fixes a problem
```r
staged.dependencies::dependency_table(
  project = "insightsengineering/tern@https://github.com",
  project_type = "repo@host",
  ref = "remove_staged_deps_link@main",
  verbose = 1
)
```