### PR TITLE
deprecate_warn instead of stop for create_afun*

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tern
 Title: Create Common TLGs Used in Clinical Trials
-Version: 0.8.5.9010
+Version: 0.8.5.9011
 Date: 2023-08-16
 Authors@R: c(
     person("Joe", "Zhu", , "joe.zhu@roche.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,15 @@
 # tern 0.8.5.9011
 
-### Miscellaneous
-* Fix swapped descriptions for the `.N_row` and `.N_col` parameters.
-* Fix bug in `analyze_vars_in_cols` when categorical data was used.
-* Removal of internal calls to `df_explicit_na`. Changes in `NA` values should happen externally to `tern` functions, depending on users' needs.
-
 ### Enhancements
 * Refactored `a_summary` to no longer use helper function `create_afun_summary`. 
 * Refactored `summarize_vars` and `compare_vars` to use refactored `a_summary`.
 * Created new internal helper functions `ungroup_stats` to ungroup statistics calculated for factor variables, and `a_summary_internal` to perform calculations for `a_summary`.
+
+### Miscellaneous
+* Fix swapped descriptions for the `.N_row` and `.N_col` parameters.
+* Fix bug in `analyze_vars_in_cols` when categorical data was used.
+* Removal of internal calls to `df_explicit_na`. Changes in `NA` values should happen externally to `tern` functions, depending on users' needs.
+* Reinstated correct soft deprecation for `create_afun_summary` and `create_afun_compare`.
 
 # tern 0.8.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tern 0.8.5.9010
+# tern 0.8.5.9011
 
 ### Miscellaneous
 * Fix swapped descriptions for the `.N_row` and `.N_col` parameters.

--- a/R/analyze_variables.R
+++ b/R/analyze_variables.R
@@ -623,13 +623,14 @@ create_afun_summary <- function(.stats, .formats, .labels, .indent_mods) {
            ...,
            .var) {
     a_summary(x,
-              .stats = .stats,
-              .formats = .formats,
-              .labels = .labels,
-              .indent_mods = .indent_mods,
-              .ref_group = .ref_group,
-              .in_ref_col = .in_ref_col,
-              .var = .var, ...)
+      .stats = .stats,
+      .formats = .formats,
+      .labels = .labels,
+      .indent_mods = .indent_mods,
+      .ref_group = .ref_group,
+      .in_ref_col = .in_ref_col,
+      .var = .var, ...
+    )
   }
 }
 

--- a/R/compare_variables.R
+++ b/R/compare_variables.R
@@ -318,14 +318,16 @@ create_afun_compare <- function(.stats = NULL,
            .in_ref_col,
            ...,
            .var) {
-    a_summary(x, compare = TRUE,
-              .stats = .stats,
-              .formats = .formats,
-              .labels = .labels,
-              .indent_mods = .indent_mods,
-              .ref_group = .ref_group,
-              .in_ref_col = .in_ref_col,
-              .var = .var, ...)
+    a_summary(x,
+      compare = TRUE,
+      .stats = .stats,
+      .formats = .formats,
+      .labels = .labels,
+      .indent_mods = .indent_mods,
+      .ref_group = .ref_group,
+      .in_ref_col = .in_ref_col,
+      .var = .var, ...
+    )
   }
 }
 

--- a/tests/testthat/test-analyze_variables.R
+++ b/tests/testthat/test-analyze_variables.R
@@ -491,6 +491,27 @@ testthat::test_that("analyze_vars 'na_level' argument works as expected", {
 
 # Deprecated functions
 
-testthat::test_that("create_afun_summary returns error message", {
-  testthat::expect_error(create_afun_summary())
+testthat::test_that("create_afun_summary creates an `afun` that works and throws a warning", {
+  testthat::expect_warning(afun <- create_afun_summary(
+    .stats = c("n", "count_fraction", "median", "range", "mean_ci"),
+    .formats = c(median = "xx."),
+    .labels = c(median = "My median"),
+    .indent_mods = c(median = 1L)
+  ))
+  dta_test <- data.frame(
+    USUBJID = rep(1:6, each = 3),
+    PARAMCD = rep("lab", 6 * 3),
+    AVISIT = rep(paste0("V", 1:3), 6),
+    ARM = rep(LETTERS[1:3], rep(6, 3)),
+    AVAL = c(9:1, rep(NA, 9)),
+    stringsAsFactors = TRUE
+  )
+
+  l <- basic_table() %>%
+    split_cols_by(var = "ARM") %>%
+    split_rows_by(var = "AVISIT") %>%
+    analyze(vars = c("AVAL", "ARM"), afun = afun)
+
+  # From visual inspection it works as before, same output
+  testthat::expect_silent(result <- build_table(l, df = dta_test))
 })

--- a/tests/testthat/test-compare_variables.R
+++ b/tests/testthat/test-compare_variables.R
@@ -128,7 +128,7 @@ testthat::test_that("compare_vars 'na_level' argument works as expected", {
 # Deprecated functions
 
 testthat::test_that("create_afun_compare returns error message", {
-  testthat::expect_error(create_afun_compare())
+  testthat::expect_warning(create_afun_compare()) # before It was not covered directly
 })
 
 testthat::test_that("a_compare returns correct output and warning message", {


### PR DESCRIPTION
Fixes #1033 

@BFalquet can I ask you to check if eventually this would work with your old function?

Nevermind, added the tests from previous version with expect_warning