### PR TITLE
add axis parameter to plot_grid()

### DIFF
--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -406,7 +406,7 @@ g_lineplot <- function(df,
     }
 
     # align plot and table
-    cowplot::plot_grid(p, tbl, ncol = 1, align = "v")
+    cowplot::plot_grid(p, tbl, ncol = 1, align = "v", axis = "tblr")
   } else {
     p
   }


### PR DESCRIPTION
follow-up on https://github.com/insightsengineering/tern/pull/1153

Integration test warns for chevron:
```
── Warning ('test-mng01.R:18:3'): mng01 works as expected with custom argument values ──
  Graphs cannot be vertically aligned unless the axis parameter is set. Placing graphs unaligned.
  Backtrace:
      ▆
   1. └─chevron::mng01_main(...) at test-mng01.R:18:3
   2.   └─base::lapply(...)
   3.     └─tern (local) FUN(X[[i]], ...)
   4.       └─cowplot::plot_grid(p, tbl, ncol = 1, align = "v")
   5.         └─cowplot::align_plots(...)
```

It might happen that snapshot test will fail. In such case please kindly provide some help. I have re-run snapshots locally and I got differences for unrelated graphs like KM Plots. This has to do with my local settings. I might be unable to get same graphs like in CI.