### PR TITLE
Revert deprecation of `decorate_grob`-related functions used by `citril`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 * Removed deprecated functions `summarize_vars`, `control_summarize_vars`, `a_compare`, `create_afun_summary`, `create_afun_compare`, and `summary_custom`.
 * Began deprecation of the `forest_grob`, `forest_dot_line`, `forest_viewport`, `vp_forest_table_part`, and `grid.forest` functions.
 * Began deprecation of no longer used Kaplan-Meier helper functions `h_ggkm`, `h_decompose_gg`, `h_km_layout`, `h_grob_tbl_at_risk`, `h_grob_median_surv`, `h_grob_y_annot`, and `h_grob_coxph`.
-* Began deprecation of `grob`/`grid` related functions `stack_grobs`, `arrange_grobs`, `draw_grob`, `decorate_grob`, `split_text_grob`, `decorate_grob_factory`, and `decorate_grob_set` which are no longer used in `tern`.
+* Began deprecation of `grob`/`grid` related functions `stack_grobs`, `arrange_grobs`, and `draw_grob` which are no longer used in `tern`.
 * Removed `vdiffr` package from Suggests in DESCRIPTION file.
 
 # tern 0.9.3

--- a/R/decorate_grob.R
+++ b/R/decorate_grob.R
@@ -1,6 +1,6 @@
 #' Add Titles, Footnotes, Page Number, and a Bounding Box to a Grid Grob
 #'
-#' @description `r lifecycle::badge("deprecated")`
+#' @description `r lifecycle::badge("stable")`
 #'
 #' This function is useful to label grid grobs (also `ggplot2`, and `lattice` plots)
 #' with title, footnote, and page numbers.
@@ -143,12 +143,6 @@ decorate_grob <- function(grob,
                           name = NULL,
                           gp = grid::gpar(),
                           vp = NULL) {
-  lifecycle::deprecate_warn(
-    "0.9.4",
-    "decorate_grob()",
-    details = "`tern` plotting functions no longer generate `grob` objects."
-  )
-
   st_titles <- split_text_grob(
     titles,
     x = 0, y = 1,
@@ -327,12 +321,6 @@ split_text_grob <- function(text,
                             name = NULL,
                             gp = grid::gpar(),
                             vp = NULL) {
-  lifecycle::deprecate_warn(
-    "0.9.4",
-    "split_text_grob()",
-    details = "`tern` plotting functions no longer generate `grob` objects."
-  )
-
   if (!grid::is.unit(x)) x <- grid::unit(x, default.units)
   if (!grid::is.unit(y)) y <- grid::unit(y, default.units)
   if (!grid::is.unit(width)) width <- grid::unit(width, default.units)
@@ -420,12 +408,6 @@ drawDetails.dynamicSplitText <- function(x, recording) {
 #'
 #' @keywords internal
 decorate_grob_factory <- function(npages, ...) {
-  lifecycle::deprecate_warn(
-    "0.9.4",
-    "decorate_grob_factory()",
-    details = "`tern` plotting functions no longer generate `grob` objects."
-  )
-
   current_page <- 0
   function(grob) {
     current_page <<- current_page + 1
@@ -438,7 +420,7 @@ decorate_grob_factory <- function(npages, ...) {
 
 #' Decorate Set of `grobs` and Add Page Numbering
 #'
-#' @description `r lifecycle::badge("deprecated")`
+#' @description `r lifecycle::badge("stable")`
 #'
 #' Note that this uses the [decorate_grob_factory()] function.
 #'
@@ -486,12 +468,6 @@ decorate_grob_factory <- function(npages, ...) {
 #'
 #' @export
 decorate_grob_set <- function(grobs, ...) {
-  lifecycle::deprecate_warn(
-    "0.9.4",
-    "decorate_grob_set()",
-    details = "`tern` plotting functions no longer generate `grob` objects."
-  )
-
   n <- length(grobs)
   lgf <- decorate_grob_factory(npages = n, ...)
   lapply(grobs, lgf)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -146,9 +146,11 @@ reference:
   - title: Graph Helper Functions
     desc: These functions are useful to modify graphs.
     contents:
-      - starts_with("decorate_")
+      - decorate_grob
+      - split_text_grob
+      - decorate_grob_factory
+      - decorate_grob_set
       - h_g_ipp
-      - matches(".*grob.*")
       - h_xticks
 
   - title: Data Helper Functions
@@ -195,4 +197,6 @@ reference:
       - h_grob_tbl_at_risk
       - h_grob_y_annot
       - h_km_layout
-
+      - stack_grobs
+      - arrange_grobs
+      - draw_grob

--- a/man/decorate_grob.Rd
+++ b/man/decorate_grob.Rd
@@ -61,7 +61,7 @@ according to the page width.}
 A grid grob (\code{gTree}).
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
 This function is useful to label grid grobs (also \code{ggplot2}, and \code{lattice} plots)
 with title, footnote, and page numbers.

--- a/man/decorate_grob_set.Rd
+++ b/man/decorate_grob_set.Rd
@@ -15,7 +15,7 @@ decorate_grob_set(grobs, ...)
 A decorated grob.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
 Note that this uses the \code{\link[=decorate_grob_factory]{decorate_grob_factory()}} function.
 }

--- a/tests/testthat/test-decorate_grob.R
+++ b/tests/testthat/test-decorate_grob.R
@@ -1,11 +1,9 @@
-# All functions deprecated
-
 testthat::test_that("decorate_grob returns no warnings when creating an empty plot", {
   titles <- "Edgar Anderson's Iris Data"
   footnotes <- "The species are Iris setosa, versicolor, and virginica."
 
   grid::grid.newpage()
-  lifecycle::expect_deprecated(lifecycle::expect_deprecated(lifecycle::expect_deprecated(
+  testthat::expect_silent(
     grid::grid.draw(
       decorate_grob(
         NULL,
@@ -17,7 +15,7 @@ testthat::test_that("decorate_grob returns no warnings when creating an empty pl
         padding = c(1, 1, 1, 1)
       )
     )
-  )))
+  )
 })
 
 testthat::test_that("decorate_grob returns no warnings when creating a non-empty plot", {
@@ -35,7 +33,7 @@ testthat::test_that("decorate_grob returns no warnings when creating a non-empty
     vp = grid::vpStack(grid::plotViewport(), grid::dataViewport(xData = iris$Sepal.Length, yData = iris$Petal.Length))
   )
   grid::grid.newpage()
-  lifecycle::expect_deprecated(lifecycle::expect_deprecated(lifecycle::expect_deprecated(
+  testthat::expect_silent(
     grid::grid.draw(
       decorate_grob(
         grob = p,
@@ -44,7 +42,7 @@ testthat::test_that("decorate_grob returns no warnings when creating a non-empty
         page = "Page 6 of 129"
       )
     )
-  )))
+  )
 })
 
 testthat::test_that("split_string works with default settings", {
@@ -57,11 +55,11 @@ testthat::test_that("split_string works with default settings", {
 })
 
 testthat::test_that("decorate_grob_factory returns page warning correctly", {
-  testthat::expect_warning(pf <- decorate_grob_factory(
+  pf <- decorate_grob_factory(
     titles = "This is a test\nHello World",
     footnotes = "Here belong the footnotess",
     npages = 0
-  ))
+  )
   suppressWarnings(testthat::expect_error(draw_grob(pf(NULL)), "current page is 1 but max. 0 specified."))
 })
 
@@ -97,9 +95,9 @@ testthat::test_that("decorate_grob_set returns no warnings when creating a non-e
       )
     })
   )
-  suppressWarnings(lifecycle::expect_deprecated(
+  testthat::expect_silent(
     lg <- decorate_grob_set(grobs = g, titles = "Hello\nOne\nTwo\nThree", footnotes = "")
-  ))
+  )
   testthat::expect_warning(draw_grob(lg[[1]]))
 })
 
@@ -107,7 +105,7 @@ testthat::test_that("text wrapping works as expected", {
   g <- ggplot2::ggplot(iris) +
     ggplot2::geom_point(aes(x = Sepal.Length, y = Sepal.Width))
 
-  lifecycle::expect_deprecated(lifecycle::expect_deprecated(lifecycle::expect_deprecated(
+  testthat::expect_silent(
     deco_grob_text_wrap <- decorate_grob(
       grob = ggplot2::ggplotGrob(g),
       titles = paste(
@@ -120,7 +118,7 @@ testthat::test_that("text wrapping works as expected", {
       ),
       page = "Page 1 of 10"
     )
-  )))
+  )
 
   expect_snapshot_ggplot(title = "deco_grob_text_wrap", fig = deco_grob_text_wrap, width = 10, height = 8)
 })


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #1218
