### PR TITLE
Manually specify shapes within `g_lineplot` when >6 group levels exist

### DIFF
--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -308,6 +308,11 @@ g_lineplot <- function(df,
     )
   )
 
+  if (nlevels(df_stats[[strata_N]]) > 6) {
+    p <- p +
+      scale_shape_manual(values = seq(15, 15 + nlevels(df_stats[[strata_N]])))
+  }
+
   if (!is.null(mid)) {
     # points
     if (grepl("p", mid_type, fixed = TRUE)) {

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -50,6 +50,19 @@ testthat::test_that("g_lineplot works with cohort_id specified", {
   expect_snapshot_ggplot(title = "g_lineplot_cohorts", fig = g_lineplot_cohorts, width = 10, height = 8)
 })
 
+testthat::test_that("g_lineplot does not produce a warning if group_var has >6 levels", {
+  set.seed(1)
+  adlb$FACTOR7 <- as.factor(sample(1:7, nrow(adlb), replace = TRUE))
+
+  testthat::expect_silent(withr::with_options(
+    opts_partial_match_old,
+    g_lineplot(
+      adlb,
+      variables = control_lineplot_vars(group_var = "FACTOR7")
+    )
+  ))
+})
+
 testthat::test_that("control_lineplot_vars works", {
   testthat::expect_silent(control_lineplot_vars(group_var = NA))
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #1233
