### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -21,6 +21,8 @@ jobs:
       strategy: ${{ matrix.test-strategy }}
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
+      extra-deps: |
+        lme4 (>= 1.1-35)
   branch-cleanup:
     name: Branch Cleanup 🧹
     uses: insightsengineering/r.pkg.template/.github/workflows/branch-cleanup.yaml@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Depends:
     rtables (>= 0.6.8)
 Imports:
     broom (>= 0.5.4),
-    car (>= 3.1-2),
+    car (>= 3.0-13),
     checkmate (>= 2.1.0),
     cowplot (>= 1.0.0),
     dplyr (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Depends:
     rtables (>= 0.6.7)
 Imports:
     broom (>= 0.5.4),
-    car (>= 3.0-13),
+    car (>= 3.1-1),
     checkmate (>= 2.1.0),
     cowplot (>= 1.0.0),
     dplyr (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Depends:
     rtables (>= 0.6.7)
 Imports:
     broom (>= 0.5.4),
-    car (>= 3.1-1),
+    car (>= 3.1-2),
     checkmate (>= 2.1.0),
     cowplot (>= 1.0.0),
     dplyr (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     lattice (>= 0.18-4),
     lubridate (>= 1.7.9),
     nestcolor (>= 0.1.1),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     stringr (>= 1.4.1),
     svglite (>= 2.1.2),
     testthat (>= 3.1.9),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.