### PR TITLE
Fixes problem with `a_surv_time` with datasets where "is_event" is always `TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tern 0.9.5.9001
 
+### Bug Fixes
+* Fixed a bug in `a_surv_time` that threw an error when split only had `"is_event"`.
+
 # tern 0.9.5
 
 ### Enhancements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tern 0.9.5.9001
 
 ### Bug Fixes
-* Fixed a bug in `a_surv_time` that threw an error when split only had `"is_event"`.
+* Fixed a bug in `a_surv_time` that threw an error when split only has `"is_event"`.
 
 # tern 0.9.5
 

--- a/R/survival_time.R
+++ b/R/survival_time.R
@@ -138,11 +138,11 @@ a_surv_time <- function(df,
 
   cell_fns <- setNames(vector("list", length = length(x_stats)), .labels)
   if ("range" %in% names(x_stats) && ref_fn_censor) {
-    if (x_stats[["range"]][1] == rng_censor_lwr && x_stats[["range"]][2] == rng_censor_upr) {
+    if (identical(x_stats[["range"]][1], rng_censor_lwr) && identical(x_stats[["range"]][2], rng_censor_upr)) {
       cell_fns[[.labels[["range"]]]] <- "Censored observations: range minimum & maximum"
-    } else if (x_stats[["range"]][1] == rng_censor_lwr) {
+    } else if (identical(x_stats[["range"]][1], rng_censor_lwr)) {
       cell_fns[[.labels[["range"]]]] <- "Censored observation: range minimum"
-    } else if (x_stats[["range"]][2] == rng_censor_upr) {
+    } else if (identical(x_stats[["range"]][2], rng_censor_upr)) {
       cell_fns[[.labels[["range"]]]] <- "Censored observation: range maximum"
     }
   }

--- a/tests/testthat/test-survival_time.R
+++ b/tests/testthat/test-survival_time.R
@@ -153,3 +153,27 @@ testthat::test_that("surv_time works with referential footnotes", {
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
 })
+
+testthat::test_that("a_surv_time works when `is_event` only has TRUE observations", {
+  anl <- tibble::tribble(
+    ~AVAL, ~ARM, ~is_event,
+    1,  "A",     TRUE,
+    2,  "A",     TRUE
+  )
+
+  testthat::expect_silent(
+    tern::a_surv_time(anl, .var = "AVAL", is_event = "is_event")
+  )
+})
+
+testthat::test_that("a_surv_time works when `is_event` only has FALSE observations", {
+  anl <- tibble::tribble(
+    ~AVAL, ~ARM, ~is_event,
+    1,  "A",     FALSE,
+    2,  "A",     FALSE
+  )
+
+  testthat::expect_silent(
+    tern::a_surv_time(anl, .var = "AVAL", is_event = "is_event")
+  )
+})

--- a/tests/testthat/test-survival_time.R
+++ b/tests/testthat/test-survival_time.R
@@ -157,8 +157,8 @@ testthat::test_that("surv_time works with referential footnotes", {
 testthat::test_that("a_surv_time works when `is_event` only has TRUE observations", {
   anl <- tibble::tribble(
     ~AVAL, ~ARM, ~is_event,
-    1,  "A",     TRUE,
-    2,  "A",     TRUE
+    1, "A", TRUE,
+    2, "A", TRUE
   )
 
   testthat::expect_silent(
@@ -169,8 +169,8 @@ testthat::test_that("a_surv_time works when `is_event` only has TRUE observation
 testthat::test_that("a_surv_time works when `is_event` only has FALSE observations", {
   anl <- tibble::tribble(
     ~AVAL, ~ARM, ~is_event,
-    1,  "A",     FALSE,
-    2,  "A",     FALSE
+    1, "A", FALSE,
+    2, "A", FALSE
   )
 
   testthat::expect_silent(


### PR DESCRIPTION
# Pull Request

- Fixes #1258 

#### Changes description

- Use `identical()` instead of `==` to compare integers
- Adds simple test for this issue
  - Was not present in some of the older version of `tern`