### PR TITLE
Update of `g_lineplot` to have line type, error bar width, and avoid empty levels in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # tern 0.9.5.9002
+### Enhancements
+* Added `errorbar_width` and `linetype` parameters to `g_lineplot`.
 
 ### Bug Fixes
 * Fixed a bug in `a_surv_time` that threw an error when split only has `"is_event"`.
+* Empty levels on `g_lineplot` x-axis are not shown in either plots.
+* Fixed disappearing line in `g_lineplot` when using only one group or strata level.
 
 # tern 0.9.5
 

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -71,6 +71,7 @@
 #' @param newpage `r lifecycle::badge("deprecated")` not used.
 #' @param col (`character`)\cr color(s).
 #' @param linetype (`character`)\cr line type(s).
+#' @param errorbar_width (`numeric(1)`)\cr width of the error bars.
 #'
 #' @return A `ggplot` line plot (and statistics table if applicable).
 #'
@@ -159,6 +160,7 @@ g_lineplot <- function(df,
                        table_format = get_formats_from_stats(table),
                        table_labels = get_labels_from_stats(table),
                        table_font_size = 3,
+                       errorbar_width = 0.45,
                        newpage = lifecycle::deprecated(),
                        col = NULL,
                        linetype = NULL) {
@@ -170,6 +172,7 @@ g_lineplot <- function(df,
   checkmate::assert_numeric(xticks, null.ok = TRUE)
   checkmate::assert_numeric(xlim, finite = TRUE, any.missing = FALSE, len = 2, sorted = TRUE, null.ok = TRUE)
   checkmate::assert_numeric(ylim, finite = TRUE, any.missing = FALSE, len = 2, sorted = TRUE, null.ok = TRUE)
+  checkmate::assert_number(errorbar_width, lower = 0)
   checkmate::assert_string(title, null.ok = TRUE)
   checkmate::assert_string(subtitle, null.ok = TRUE)
 
@@ -345,7 +348,7 @@ g_lineplot <- function(df,
     p <- p +
       ggplot2::geom_errorbar(
         ggplot2::aes(ymin = .data[[whiskers[1]]], ymax = .data[[whiskers[max(1, length(whiskers))]]]),
-        width = 0.45,
+        width = errorbar_width,
         position = position
       )
 

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -331,10 +331,8 @@ g_lineplot <- function(df,
       p <- p + ggplot2::geom_point(position = position, size = mid_point_size, na.rm = TRUE)
     }
 
-    # lines
-    # further conditions in if are to ensure that not all of the groups consist of only one observation
-    if (grepl("l", mid_type, fixed = TRUE) && !is.null(group_var) &&
-      !all(dplyr::summarise(df_grp, count_n = dplyr::n())[["count_n"]] == 1L)) { # nolint
+    # lines - plotted only if there is a strata grouping (group_var)
+    if (grepl("l", mid_type, fixed = TRUE) && !is.null(strata_N)) { # nolint
       p <- p + ggplot2::geom_line(position = position, na.rm = TRUE)
     }
   }

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -230,6 +230,9 @@ g_lineplot <- function(df,
   ####################################### |
   # ---- Compute required statistics ----
   ####################################### |
+  # Remove unused levels for x-axis
+  df[[x]] <- droplevels(df[[x]])
+
   if (!is.null(facet_var) && !is.null(group_var)) {
     df_grp <- tidyr::expand(df, .data[[facet_var]], .data[[group_var]], .data[[x]]) # expand based on levels of factors
   } else if (!is.null(group_var)) {
@@ -237,6 +240,7 @@ g_lineplot <- function(df,
   } else {
     df_grp <- tidyr::expand(df, NULL, .data[[x]])
   }
+
   df_grp <- df_grp %>%
     dplyr::full_join(y = df[, c(facet_var, group_var, x, y)], by = c(facet_var, group_var, x), multiple = "all") %>%
     dplyr::group_by_at(c(facet_var, group_var, x))

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -69,8 +69,8 @@
 #'   appended to the plot. Names of `table_labels` must match the names of statistics returned by `sfun` function.
 #' @param table_font_size (`numeric(1)`)\cr font size of the text in the table.
 #' @param newpage `r lifecycle::badge("deprecated")` not used.
-#' @param col (`character`)\cr color(s).
-#' @param linetype (`character`)\cr line type(s).
+#' @param col (`character`)\cr color(s). See `?ggplot2::aes_colour_fill_alpha` for example values.
+#' @param linetype (`character`)\cr line type(s). See `?ggplot2::aes_linetype_size_shape` for example values.
 #' @param errorbar_width (`numeric(1)`)\cr width of the error bars.
 #'
 #' @return A `ggplot` line plot (and statistics table if applicable).

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -231,7 +231,9 @@ g_lineplot <- function(df,
   # ---- Compute required statistics ----
   ####################################### |
   # Remove unused levels for x-axis
-  df[[x]] <- droplevels(df[[x]])
+  if (is.factor(df[[x]])) {
+    df[[x]] <- droplevels(df[[x]])
+  }
 
   if (!is.null(facet_var) && !is.null(group_var)) {
     df_grp <- tidyr::expand(df, .data[[facet_var]], .data[[group_var]], .data[[x]]) # expand based on levels of factors

--- a/R/g_lineplot.R
+++ b/R/g_lineplot.R
@@ -70,6 +70,7 @@
 #' @param table_font_size (`numeric(1)`)\cr font size of the text in the table.
 #' @param newpage `r lifecycle::badge("deprecated")` not used.
 #' @param col (`character`)\cr color(s).
+#' @param linetype (`character`)\cr line type(s).
 #'
 #' @return A `ggplot` line plot (and statistics table if applicable).
 #'
@@ -159,11 +160,13 @@ g_lineplot <- function(df,
                        table_labels = get_labels_from_stats(table),
                        table_font_size = 3,
                        newpage = lifecycle::deprecated(),
-                       col = NULL) {
+                       col = NULL,
+                       linetype = NULL) {
   checkmate::assert_character(variables, any.missing = TRUE)
   checkmate::assert_character(mid, null.ok = TRUE)
   checkmate::assert_character(interval, null.ok = TRUE)
   checkmate::assert_character(col, null.ok = TRUE)
+  checkmate::assert_character(linetype, null.ok = TRUE)
   checkmate::assert_numeric(xticks, null.ok = TRUE)
   checkmate::assert_numeric(xlim, finite = TRUE, any.missing = FALSE, len = 2, sorted = TRUE, null.ok = TRUE)
   checkmate::assert_numeric(ylim, finite = TRUE, any.missing = FALSE, len = 2, sorted = TRUE, null.ok = TRUE)
@@ -380,6 +383,10 @@ g_lineplot <- function(df,
   if (!is.null(col)) {
     p <- p +
       ggplot2::scale_color_manual(values = col)
+  }
+  if (!is.null(linetype)) {
+    p <- p +
+      ggplot2::scale_linetype_manual(values = linetype)
   }
 
   if (!is.null(facet_var)) {

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -36,7 +36,8 @@ g_lineplot(
   table_labels = get_labels_from_stats(table),
   table_font_size = 3,
   newpage = lifecycle::deprecated(),
-  col = NULL
+  col = NULL,
+  linetype = NULL
 )
 }
 \arguments{
@@ -143,6 +144,8 @@ appended to the plot. Names of \code{table_labels} must match the names of stati
 \item{newpage}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} not used.}
 
 \item{col}{(\code{character})\cr color(s).}
+
+\item{linetype}{(\code{character})\cr line type(s).}
 }
 \value{
 A \code{ggplot} line plot (and statistics table if applicable).

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -146,9 +146,9 @@ appended to the plot. Names of \code{table_labels} must match the names of stati
 
 \item{newpage}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} not used.}
 
-\item{col}{(\code{character})\cr color(s).}
+\item{col}{(\code{character})\cr color(s). See \code{?ggplot2::aes_colour_fill_alpha} for example values.}
 
-\item{linetype}{(\code{character})\cr line type(s).}
+\item{linetype}{(\code{character})\cr line type(s). See \code{?ggplot2::aes_linetype_size_shape} for example values.}
 }
 \value{
 A \code{ggplot} line plot (and statistics table if applicable).

--- a/man/g_lineplot.Rd
+++ b/man/g_lineplot.Rd
@@ -35,6 +35,7 @@ g_lineplot(
   table_format = get_formats_from_stats(table),
   table_labels = get_labels_from_stats(table),
   table_font_size = 3,
+  errorbar_width = 0.45,
   newpage = lifecycle::deprecated(),
   col = NULL,
   linetype = NULL
@@ -140,6 +141,8 @@ parameter. Names of \code{table_format} must match the names of statistics retur
 appended to the plot. Names of \code{table_labels} must match the names of statistics returned by \code{sfun} function.}
 
 \item{table_font_size}{(\code{numeric(1)})\cr font size of the text in the table.}
+
+\item{errorbar_width}{(\code{numeric(1)})\cr width of the error bars.}
 
 \item{newpage}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} not used.}
 

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -185,7 +185,9 @@ testthat::test_that("g_lineplot works with no strata (group_var) and allows poin
     )
   )
 })
+
 testthat::test_that("linetype works as well as col with manual scaling and other options (errorbar_width)", {
+  # Regression test issues #1235 #1236 #1081
   g_lineplot_linetype <- testthat::expect_silent(
     withr::with_options(
       opts_partial_match_old,
@@ -194,8 +196,22 @@ testthat::test_that("linetype works as well as col with manual scaling and other
         adsl,
         variables = control_lineplot_vars(group_var = "ARM"),
         col = c("blue", "black", "blue"),
-        linetype = c("dashed", "solid", "dashed"),
-        errorbar_width = 0.6
+        linetype = c("dashed", "solid", "dashed"), # Visual testing necessary here
+        errorbar_width = 1.6 # Visual testing necessary here
+      )
+    )
+  )
+})
+
+testthat::test_that("NA values are removed also from the table plot", {
+  # Regression test issues teal.modules.clinical#1197
+  levels(adlb$AVISIT) <- c(levels(adlb$AVISIT), "Not present")
+  g_lineplot_linetype <- testthat::expect_silent(
+    withr::with_options(
+      opts_partial_match_old,
+      g_lineplot(
+        adlb,
+        table = "n" # Visual testing necessary here
       )
     )
   )

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -158,7 +158,7 @@ testthat::test_that("g_lineplot works with no strata (group_var) and allows poin
       variables = control_lineplot_vars(group_var = NULL)
     )
   )
-  testthat::expect_true(
+  testthat::expect_false( # no group variable
     any(
       vapply(
         g_lineplot_no_strata$layers, function(x) {
@@ -178,6 +178,23 @@ testthat::test_that("g_lineplot works with no strata (group_var) and allows poin
     any(
       vapply(
         g_lineplot_strata$layers, function(x) {
+          any(grepl(class(x$geom), pattern = "line", ignore.case = TRUE))
+        },
+        logical(1L)
+      )
+    )
+  )
+  g_lineplot_single_strata <- withr::with_options(
+    opts_partial_match_old,
+    g_lineplot(
+      adlb2,
+      adsl2
+    )
+  )
+  testthat::expect_true( # only one group variable
+    any(
+      vapply(
+        g_lineplot_single_strata$layers, function(x) {
           any(grepl(class(x$geom), pattern = "line", ignore.case = TRUE))
         },
         logical(1L)

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -142,3 +142,46 @@ testthat::test_that("control_lineplot_vars works", {
   # Deprecation warnings work
   lifecycle::expect_deprecated(lifecycle::expect_deprecated(control_lineplot_vars(strata = NA, cohort_id = NA)))
 })
+
+testthat::test_that("g_lineplot works with no strata (group_var) and allows points when only one strata is provided", {
+  adlb2 <- adlb |>
+    dplyr::filter(USUBJID == "AB12345-BRA-1-id-105")
+
+  adsl2 <- adsl |>
+    dplyr::filter(USUBJID == "AB12345-BRA-1-id-105")
+
+  g_lineplot_no_strata <- withr::with_options(
+    opts_partial_match_old,
+    g_lineplot(
+      adlb2,
+      adsl2,
+      variables = control_lineplot_vars(group_var = NULL)
+    )
+  )
+  testthat::expect_true(
+    any(
+      vapply(
+        g_lineplot_no_strata$layers, function(x) {
+          any(grepl(class(x$geom), pattern = "line", ignore.case = TRUE))
+        },
+        logical(1L)
+      )
+    )
+  )
+  g_lineplot_strata <- withr::with_options(
+    opts_partial_match_old,
+    g_lineplot(
+      adlb2
+    )
+  )
+  testthat::expect_true(
+    any(
+      vapply(
+        g_lineplot_strata$layers, function(x) {
+          any(grepl(class(x$geom), pattern = "line", ignore.case = TRUE))
+        },
+        logical(1L)
+      )
+    )
+  )
+})

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -185,7 +185,7 @@ testthat::test_that("g_lineplot works with no strata (group_var) and allows poin
     )
   )
 })
-testthat::test_that("linetype works as well as col with manual scaling", {
+testthat::test_that("linetype works as well as col with manual scaling and other options (errorbar_width)", {
   g_lineplot_linetype <- testthat::expect_silent(
     withr::with_options(
       opts_partial_match_old,
@@ -194,7 +194,8 @@ testthat::test_that("linetype works as well as col with manual scaling", {
         adsl,
         variables = control_lineplot_vars(group_var = "ARM"),
         col = c("blue", "black", "blue"),
-        linetype = c("dashed", "solid", "dashed")
+        linetype = c("dashed", "solid", "dashed"),
+        errorbar_width = 0.6
       )
     )
   )

--- a/tests/testthat/test-g_lineplot.R
+++ b/tests/testthat/test-g_lineplot.R
@@ -185,3 +185,17 @@ testthat::test_that("g_lineplot works with no strata (group_var) and allows poin
     )
   )
 })
+testthat::test_that("linetype works as well as col with manual scaling", {
+  g_lineplot_linetype <- testthat::expect_silent(
+    withr::with_options(
+      opts_partial_match_old,
+      g_lineplot(
+        adlb,
+        adsl,
+        variables = control_lineplot_vars(group_var = "ARM"),
+        col = c("blue", "black", "blue"),
+        linetype = c("dashed", "solid", "dashed")
+      )
+    )
+  )
+})


### PR DESCRIPTION
Completes #1235 #1236 #1081 and https://github.com/insightsengineering/teal.modules.clinical/issues/1197