### PR TITLE
Fix handling of `decorate_grob` for empty strings and NULL in titles and footers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Fixed disappearing line in `g_lineplot` when using only one group or strata level.
 * Fixed defaults for formats and labels in `get_formats_from_stats` and `get_labels_from_stats`.
 * Fixed bug for linear scaling factor (`scale` parameter) being applied to response but not to rate in `h_glm_count` while all distributions have logarithmic link function.
+* Fixed bug in `decorate_grob` that did not handle well empty strings or `NULL` values for title and footers.
 
 ### Miscellaneous
 * Began deprecation of the confusing functions `summary_formats` and `summary_labels`.

--- a/R/decorate_grob.R
+++ b/R/decorate_grob.R
@@ -319,7 +319,7 @@ split_text_grob <- function(text,
     ti == ""
   })
   if (any(text_is_empty)) {
-    text[text_is_empty] <- "\n"
+    text[text_is_empty] <- " "
   }
 
   if (!grid::is.unit(x)) x <- grid::unit(x, default.units)

--- a/R/decorate_grob.R
+++ b/R/decorate_grob.R
@@ -310,11 +310,15 @@ split_text_grob <- function(text,
   if ((length(text) == 1 && text == "") || length(text) == 0) {
     stop(substitute(text), " is NULL or an empty string. Please provide a valid text.")
   }
-  if(any(sapply(text, function(ti) {is.na(ti)}))) {
+  if (any(sapply(text, function(ti) {
+    is.na(ti)
+  }))) {
     stop(substitute(text), " contains NA values. Please provide a valid text.")
   }
-  text_is_empty <- sapply(text, function(ti) {ti == ""})
-  if(any(text_is_empty)) {
+  text_is_empty <- sapply(text, function(ti) {
+    ti == ""
+  })
+  if (any(text_is_empty)) {
     text[text_is_empty] <- "\n"
   }
 

--- a/R/decorate_grob.R
+++ b/R/decorate_grob.R
@@ -306,6 +306,18 @@ split_text_grob <- function(text,
                             name = NULL,
                             gp = grid::gpar(),
                             vp = NULL) {
+  # Silly checks for text
+  if ((length(text) == 1 && text == "") || length(text) == 0) {
+    stop(substitute(text), " is NULL or an empty string. Please provide a valid text.")
+  }
+  if(any(sapply(text, function(ti) {is.na(ti)}))) {
+    stop(substitute(text), " contains NA values. Please provide a valid text.")
+  }
+  text_is_empty <- sapply(text, function(ti) {ti == ""})
+  if(any(text_is_empty)) {
+    text[text_is_empty] <- "\n"
+  }
+
   if (!grid::is.unit(x)) x <- grid::unit(x, default.units)
   if (!grid::is.unit(y)) y <- grid::unit(y, default.units)
   if (!grid::is.unit(width)) width <- grid::unit(width, default.units)

--- a/man/add_riskdiff.Rd
+++ b/man/add_riskdiff.Rd
@@ -31,7 +31,7 @@ when creating a table layout.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Wrapper function for \code{\link[rtables:add_combo_levels]{rtables::add_combo_levels()}} which configures settings for the risk difference
+Wrapper function for \code{\link[rtables:add_overall_level]{rtables::add_combo_levels()}} which configures settings for the risk difference
 column to be added to an \code{rtables} object. To add a risk difference column to a table, this function
 should be used as \code{split_fun} in calls to \code{\link[rtables:split_cols_by]{rtables::split_cols_by()}}, followed by setting argument
 \code{riskdiff} to \code{TRUE} in all following analyze function calls.

--- a/man/groups_list_to_df.Rd
+++ b/man/groups_list_to_df.Rd
@@ -14,7 +14,7 @@ levels that belong to it in the character vectors that are elements of the list.
 A \code{tibble} in the required format.
 }
 \description{
-This converts a list of group levels into a data frame format which is expected by \code{\link[rtables:add_combo_levels]{rtables::add_combo_levels()}}.
+This converts a list of group levels into a data frame format which is expected by \code{\link[rtables:add_overall_level]{rtables::add_combo_levels()}}.
 }
 \examples{
 grade_groups <- list(

--- a/tests/testthat/test-decorate_grob.R
+++ b/tests/testthat/test-decorate_grob.R
@@ -123,3 +123,24 @@ testthat::test_that("text wrapping works as expected", {
 
   expect_snapshot_ggplot(title = "deco_grob_text_wrap", fig = deco_grob_text_wrap, width = 10, height = 8)
 })
+
+testthat::test_that("Edge cases work for titles and footers in split_text_grob", {
+  # regression test #1254
+  should_appear <- NULL
+  testthat::expect_error(
+    split_text_grob(should_appear),
+    "should_appear is NULL or an empty string. Please provide a valid text."
+  )
+  should_appear <- ""
+  testthat::expect_error(
+    split_text_grob(should_appear),
+    "should_appear is NULL or an empty string. Please provide a valid text."
+  )
+  should_appear <- c("", NA)
+  testthat::expect_error(
+    split_text_grob(should_appear),
+    "should_appear contains NA values. Please provide a valid text."
+  )
+  should_appear <- c("", "a a")
+  testthat::expect_silent(split_text_grob(should_appear)) # no more error (replaced by " ")
+})


### PR DESCRIPTION
#1254 