### PR TITLE
feat: added "fraction" statistic to the "analyze_var_count" method group

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * Added the `riskdiff` argument to `tabulate_rsp_subgroups` and `tabulate_survival_subgroups` to allow users to add a risk difference table column, and function `control_riskdiff` to specify settings for the risk difference column.
 * Added warning to `tabulate_rsp_subgroups` when `pval` statistic is selected but `df` has not been correctly generated to add p-values to the output table.
 * Added `n_rate` statistic as a non-default option to `estimate_incidence_rate` which returns both number of events observed and estimated incidence rate.
+* Added `fraction` statistic to the `analyze_var_count` method group.
+
 
 ### Bug Fixes
 * Fixed a bug in `a_surv_time` that threw an error when split only has `"is_event"`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,6 @@
 * Added `n_rate` statistic as a non-default option to `estimate_incidence_rate` which returns both number of events observed and estimated incidence rate.
 * Added `fraction` statistic to the `analyze_var_count` method group.
 
-
 ### Bug Fixes
 * Fixed a bug in `a_surv_time` that threw an error when split only has `"is_event"`.
 * Added defaults for `d_count_cumulative` parameters as described in the documentation.

--- a/R/analyze_variables.R
+++ b/R/analyze_variables.R
@@ -310,6 +310,10 @@ s_summary.factor <- function(x,
       c(x, ifelse(dn > 0, x / dn, 0))
     }
   )
+  y$fraction <- lapply(
+    y$count,
+    function(count) c("num" = count, "denom" = dn)
+  )
 
   y$n_blq <- sum(grepl("BLQ|LTR|<[1-9]|<PCLLOQ", x))
 

--- a/R/utils_default_stats_formats_labels.R
+++ b/R/utils_default_stats_formats_labels.R
@@ -368,7 +368,7 @@ tern_default_stats <- list(
   abnormal_by_worst_grade = c("count_fraction", "count_fraction_fixed_dp"),
   abnormal_by_worst_grade_worsen = c("fraction"),
   analyze_patients_exposure_in_cols = c("n_patients", "sum_exposure"),
-  analyze_vars_counts = c("n", "count", "count_fraction", "count_fraction_fixed_dp", "n_blq"),
+  analyze_vars_counts = c("n", "count", "count_fraction", "count_fraction_fixed_dp", "fraction", "n_blq"),
   analyze_vars_numeric = c(
     "n", "sum", "mean", "sd", "se", "mean_sd", "mean_se", "mean_ci", "mean_sei", "mean_sdi", "mean_pval",
     "median", "mad", "median_ci", "quantiles", "iqr", "range", "min", "max", "median_range", "cv",

--- a/tests/testthat/_snaps/analyze_variables.md
+++ b/tests/testthat/_snaps/analyze_variables.md
@@ -628,6 +628,20 @@
       [1] 4.0000000 0.4444444
       
       
+      $fraction
+      $fraction$Female
+        num denom 
+          2     9 
+      
+      $fraction$Male
+        num denom 
+          3     9 
+      
+      $fraction$Unknown
+        num denom 
+          4     9 
+      
+      
       $n_blq
       [1] 0
       
@@ -668,6 +682,24 @@
       [1] 1.0000000 0.1428571
       
       
+      $fraction
+      $fraction$Female
+        num denom 
+          2     7 
+      
+      $fraction$Male
+        num denom 
+          2     7 
+      
+      $fraction$Unknown
+        num denom 
+          2     7 
+      
+      $fraction$`NA`
+        num denom 
+          1     7 
+      
+      
       $n_blq
       [1] 0
       
@@ -700,6 +732,20 @@
       
       $count_fraction$Unknown
       [1] 4.0000000 0.4444444
+      
+      
+      $fraction
+      $fraction$Female
+        num denom 
+          2     9 
+      
+      $fraction$Male
+        num denom 
+          3     9 
+      
+      $fraction$Unknown
+        num denom 
+          4     9 
       
       
       $n_blq
@@ -736,6 +782,20 @@
       [1] 0 0
       
       
+      $fraction
+      $fraction$a
+        num denom 
+          0     0 
+      
+      $fraction$b
+        num denom 
+          0     0 
+      
+      $fraction$c
+        num denom 
+          0     0 
+      
+      
       $n_blq
       [1] 0
       
@@ -770,6 +830,20 @@
       [1] 4.0 0.2
       
       
+      $fraction
+      $fraction$Female
+        num denom 
+          2    20 
+      
+      $fraction$Male
+        num denom 
+          3    20 
+      
+      $fraction$Unknown
+        num denom 
+          4    20 
+      
+      
       $n_blq
       [1] 0
       
@@ -802,6 +876,20 @@
       
       $count_fraction$Unknown
       [1] 4.0000000 0.1333333
+      
+      
+      $fraction
+      $fraction$Female
+        num denom 
+          2    30 
+      
+      $fraction$Male
+        num denom 
+          3    30 
+      
+      $fraction$Unknown
+        num denom 
+          4    30 
       
       
       $n_blq
@@ -842,6 +930,24 @@
       
       $count_fraction$`NA`
       [1] 1.0 0.1
+      
+      
+      $fraction
+      $fraction$Female
+        num denom 
+          2    10 
+      
+      $fraction$Male
+        num denom 
+          3    10 
+      
+      $fraction$Unknown
+        num denom 
+          4    10 
+      
+      $fraction$`NA`
+        num denom 
+          1    10 
       
       
       $n_blq
@@ -971,7 +1077,10 @@
       8         a      3 (60.0%)          0         a
       9         b      1 (20.0%)          0         b
       10        c      1 (20.0%)          0         c
-      11    n_blq              0          0     n_blq
+      11        a    3/5 (60.0%)          0         a
+      12        b    1/5 (20.0%)          0         b
+      13        c    1/5 (20.0%)          0         c
+      14    n_blq              0          0     n_blq
 
 ---
 
@@ -991,7 +1100,10 @@
       8         A      2 (50.0%)          0         A
       9         B      1 (25.0%)          0         B
       10        C      1 (25.0%)          0         C
-      11    n_blq              0          0     n_blq
+      11        A    2/4 (50.0%)          0         A
+      12        B    1/4 (25.0%)          0         B
+      13        C    1/4 (25.0%)          0         C
+      14    n_blq              0          0     n_blq
 
 ---
 
@@ -1005,7 +1117,8 @@
       2          count              3          0          count
       3 count_fraction        3 (60%)          0 count_fraction
       4 count_fraction      3 (60.0%)          0 count_fraction
-      5          n_blq              0          0          n_blq
+      5       fraction                         0       fraction
+      6          n_blq              0          0          n_blq
 
 # a_summary works with custom input.
 
@@ -1039,7 +1152,11 @@
       11                 b      1 (20.0%)          0                 b
       12                 c      1 (20.0%)          0                 c
       13                NA      1 (20.0%)          0                NA
-      14             n_blq              0          0             n_blq
+      14                 a    2/5 (40.0%)          0                 a
+      15                 b    1/5 (20.0%)          0                 b
+      16                 c    1/5 (20.0%)          0                 c
+      17                NA    1/5 (20.0%)          0                NA
+      18             n_blq              0          0             n_blq
 
 # a_summary works with healthy input when compare = TRUE.
 
@@ -1093,8 +1210,11 @@
       8                           a      3 (60.0%)          0                          a
       9                           b      1 (20.0%)          0                          b
       10                          c      1 (20.0%)          0                          c
-      11                      n_blq              0          0                      n_blq
-      12 p-value (chi-squared test)         0.9560          0 p-value (chi-squared test)
+      11                          a    3/5 (60.0%)          0                          a
+      12                          b    1/5 (20.0%)          0                          b
+      13                          c    1/5 (20.0%)          0                          c
+      14                      n_blq              0          0                      n_blq
+      15 p-value (chi-squared test)         0.9560          0 p-value (chi-squared test)
 
 ---
 
@@ -1114,8 +1234,11 @@
       8                           A      2 (50.0%)          0                          A
       9                           B      1 (25.0%)          0                          B
       10                          C      1 (25.0%)          0                          C
-      11                      n_blq              0          0                      n_blq
-      12 p-value (chi-squared test)         0.9074          0 p-value (chi-squared test)
+      11                          A    2/4 (50.0%)          0                          A
+      12                          B    1/4 (25.0%)          0                          B
+      13                          C    1/4 (25.0%)          0                          C
+      14                      n_blq              0          0                      n_blq
+      15 p-value (chi-squared test)         0.9074          0 p-value (chi-squared test)
 
 ---
 
@@ -1129,8 +1252,9 @@
       2                      count              3          0                      count
       3             count_fraction        3 (60%)          0             count_fraction
       4             count_fraction      3 (60.0%)          0             count_fraction
-      5                      n_blq              0          0                      n_blq
-      6 p-value (chi-squared test)         0.8091          0 p-value (chi-squared test)
+      5                   fraction                         0                   fraction
+      6                      n_blq              0          0                      n_blq
+      7 p-value (chi-squared test)         0.8091          0 p-value (chi-squared test)
 
 # a_summary works with custom input when compare = TRUE.
 
@@ -1164,8 +1288,12 @@
       11                          b      1 (20.0%)          0                          b
       12                          c      1 (20.0%)          0                          c
       13                         NA      1 (20.0%)          0                         NA
-      14                      n_blq              0          0                      n_blq
-      15 p-value (chi-squared test)         0.8254          0 p-value (chi-squared test)
+      14                          a    2/5 (40.0%)          0                          a
+      15                          b    1/5 (20.0%)          0                          b
+      16                          c    1/5 (20.0%)          0                          c
+      17                         NA    1/5 (20.0%)          0                         NA
+      18                      n_blq              0          0                      n_blq
+      19 p-value (chi-squared test)         0.8254          0 p-value (chi-squared test)
 
 # `analyze_vars` works with healthy input, default `na.rm = TRUE`.
 

--- a/tests/testthat/_snaps/compare_variables.md
+++ b/tests/testthat/_snaps/compare_variables.md
@@ -21,8 +21,8 @@
     Code
       res
     Output
-      [1] "n"              "count"          "count_fraction" "n_blq"         
-      [5] "pval_counts"   
+      [1] "n"              "count"          "count_fraction" "fraction"      
+      [5] "n_blq"          "pval_counts"   
 
 ---
 
@@ -73,6 +73,20 @@
       
       $count_fraction$c
       [1] 1.0 0.2
+      
+      
+      $fraction
+      $fraction$a
+        num denom 
+          3     5 
+      
+      $fraction$b
+        num denom 
+          1     5 
+      
+      $fraction$c
+        num denom 
+          1     5 
       
       
       $n_blq

--- a/tests/testthat/_snaps/utils_default_stats_formats_labels.md
+++ b/tests/testthat/_snaps/utils_default_stats_formats_labels.md
@@ -20,7 +20,7 @@
     Output
       [1] "n"                       "count"                  
       [3] "count_fraction"          "count_fraction_fixed_dp"
-      [5] "n_blq"                  
+      [5] "fraction"                "n_blq"                  
 
 ---
 
@@ -138,6 +138,8 @@
                                "n"                      "count" 
                     count_fraction      count_fraction_fixed_dp 
                   "count_fraction"             "count_fraction" 
-                             n_blq                  pval_counts 
-                           "n_blq" "p-value (chi-squared test)" 
+                          fraction                        n_blq 
+                        "fraction"                      "n_blq" 
+                       pval_counts 
+      "p-value (chi-squared test)" 
 


### PR DESCRIPTION
Hello,

I wanted to display the count statistic in roughly this format: `xx / xx (xx.xx%)`, but it's impossible to use `analyze_vars` in this manner. I could implement my own `analyze_vars` and the associated functions, but I only need this slight change in the code, and copying the whole thing seems like an overkill.

Let me know if there's a more straightforward solution to display these statistics using the existing API (and not lose the S3 dispatch on different types of input variables).

@shajoezhu @pawelru @gogonzo If you can point me to the correct person to approach regarding this, I'd be grateful.
