### PR TITLE
Fix warning from `get_formats_from_stats()`

### DIFF
--- a/R/utils_default_stats_formats_labels.R
+++ b/R/utils_default_stats_formats_labels.R
@@ -286,6 +286,8 @@ get_formats_from_stats <- function(stats,
   out <- .fill_in_vals_by_stats(levels_per_stats, formats_in, tern_defaults)
 
   # Default to NULL if no format
+  which_null <- names(which(sapply(levels_per_stats, is.null)))
+  levels_per_stats[which_null] <- which_null
   case_input_is_not_stat <- unlist(out, use.names = FALSE) == unlist(levels_per_stats, use.names = FALSE)
   out[names(out) == out | case_input_is_not_stat] <- list(NULL)
 


### PR DESCRIPTION
# Pull Request

Fixes #1419 

I think Davide reported this when he first made the function but it was only producing the warning locally at the time.
